### PR TITLE
Fix OAuth state parameter parsing for composite states

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,16 +92,25 @@ const getFrontendUrl = (req, options = {}) => {
     return process.env.FRONTEND_URL;
   }
   
-  // Legacy state parameter support
-  if (state === 'dev' || state === 'development' || process.env.DEV_MODE === 'true') {
+  // Legacy state parameter support - check for base state only
+  const baseState = state ? state.split('&')[0] : state;
+  if (enableLogging) console.log('🔍 Base state extracted:', baseState);
+  
+  if (baseState === 'dev' || baseState === 'development' || process.env.DEV_MODE === 'true') {
     if (enableLogging) console.log('✅ Development environment detected');
-    return 'https://localhost:3000';
+    return 'https://localhost:3001';
   }
   
   // Enhanced production state detection
-  if (state === 'prod' || state === 'production' || (state && state.startsWith('prod'))) {
+  if (baseState === 'prod' || baseState === 'production' || (baseState && baseState.startsWith('prod'))) {
     if (enableLogging) console.log('✅ Production environment detected (legacy)');
-    return 'https://vikings-eventmgmt.onrender.com';
+    return 'https://vikingeventmgmt.onrender.com';
+  }
+  
+  // Special case for dev-to-prod (local frontend to deployed backend)
+  if (baseState === 'dev-to-prod') {
+    if (enableLogging) console.log('✅ Dev-to-prod environment detected');
+    return 'https://localhost:3001';
   }
   
   // Default fallback


### PR DESCRIPTION
## Summary
Fixes OAuth callback URL determination when state parameters contain embedded frontend URLs.

## Problem
When React frontend runs locally against deployed backend, it generates state like:
`dev&frontend_url=https://localhost:3001`

The backend's legacy state parsing failed because it checked for exact matches like `state === 'dev'`, but the actual state was `'dev&frontend_url=https://localhost:3001'`.

## Solution
- **Extract base state**: Use `state.split('&')[0]` before checking legacy states
- **Support composite states**: Handle states like `'dev&frontend_url=...'` properly  
- **Add dev-to-prod support**: Special state for local frontend → deployed backend
- **Update ports**: Change localhost port from 3000 to 3001 for React frontend
- **Update URLs**: Correct production frontend URLs

## Test Plan
- [x] All 13 backend tests pass
- [x] OAuth debug endpoint shows correct behavior
- [ ] Manual testing: Local React frontend → Deployed backend OAuth flow
- [ ] Verify callback redirects to correct localhost:3001 URL

## Technical Details
**Before**: `if (state === 'dev')` ❌ fails for `'dev&frontend_url=...'`  
**After**: `if (baseState === 'dev')` ✅ works for composite states

The fix maintains backward compatibility while supporting embedded frontend URLs in state parameters.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the production URL to fix a hostname typo.
  * Improved environment detection for development and production modes.

* **New Features**
  * Added support for a new "dev-to-prod" environment case.

* **Chores**
  * Enhanced logging for environment detection processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->