### PR TITLE
Remove metadata from members grid API response

### DIFF
--- a/controllers/osm-legacy.js
+++ b/controllers/osm-legacy.js
@@ -166,10 +166,7 @@ const transformMemberGridData = (rawData) => {
     status: true,
     data: {
       members: transformedMembers,
-      metadata: {
-        contact_groups: contactGroups,
-        column_mapping: columnMapping,
-      },
+      // Metadata removed - no longer needed since fields are flattened onto member objects
     },
   };
 };


### PR DESCRIPTION
## Summary
Removes `contact_groups` and `column_mapping` metadata from the `/get-members-grid` API response to reduce response size and simplify frontend processing.

## Changes
- Remove metadata section from API response
- Backend still uses metadata internally for field flattening transformation
- Cleaner response structure with only the transformed member data

## Before
```json
{
  "status": true,
  "data": {
    "members": [...],
    "metadata": {
      "contact_groups": [...],
      "column_mapping": {...}
    }
  }
}
```

## After
```json
{
  "status": true,
  "data": {
    "members": [...] // Members with flattened custom fields
  }
}
```

## Benefits
- **Reduced response size** - No more large metadata arrays
- **Simplified frontend** - No need to handle/store metadata
- **Cleaner caching** - Less data in localStorage/SQLite

## Test Plan
- [ ] Deploy to development
- [ ] Verify `/get-members-grid` response excludes metadata
- [ ] Confirm flattened fields still work correctly
- [ ] Test frontend member loading/caching

🤖 Generated with [Claude Code](https://claude.ai/code)