### PR TITLE
Fix PR preview redirect pattern to match actual Render.com format

### DIFF
--- a/__tests__/security.test.js
+++ b/__tests__/security.test.js
@@ -28,7 +28,7 @@ describe('Frontend URL Validation Security', () => {
     
     test('should accept valid PR preview URLs', async () => {
       const response = await request(app)
-        .get('/oauth/callback?frontend_url=https://pr-123-vikings-eventmgmt.onrender.com');
+        .get('/oauth/callback?frontend_url=https://vikingeventmgmt-pr-123.onrender.com');
       
       expect(response.status).toBe(302);
     });

--- a/server.js
+++ b/server.js
@@ -72,8 +72,8 @@ const validateFrontendUrl = (url) => {
       return true;
     }
     
-    // Check PR preview pattern: pr-{number}-{app}.onrender.com
-    const prPreviewPattern = /^pr-\d+-vikings?-?eventmgmt(-mobile)?\.onrender\.com$/;
+    // Check PR preview pattern: {app}-pr-{number}.onrender.com
+    const prPreviewPattern = /^vikingeventmgmt-pr-\d+\.onrender\.com$/;
     if (prPreviewPattern.test(hostname)) {
       return true;
     }


### PR DESCRIPTION
## Summary

This PR fixes the critical issue where PR previews were redirecting users to production instead of staying on the PR preview URL after OAuth authentication.

### Problem Analysis

**Issue**: PR preview URL `https://vikingeventmgmt-pr-17.onrender.com` was redirecting to production `https://vikingeventmgmt.onrender.com` after OAuth login.

**Root Cause**: Backend had **inconsistent PR preview URL patterns**:
- ✅ **CORS pattern** (line 208): `/^https:\/\/vikingeventmgmt-pr-\d+\.onrender\.com$/` - CORRECT
- ❌ **URL validation pattern** (line 76): `/^pr-\d+-vikings?-?eventmgmt(-mobile)?\.onrender\.com$/` - WRONG

### The Issue Flow

1. **CORS validation passed** → Frontend could make API calls
2. **URL validation failed** → Backend rejected PR preview URL as invalid
3. **OAuth callback fallback** → Backend redirected to production default
4. **User ended up on production** instead of staying on PR preview

### Solution

**Fixed URL validation pattern**:
```javascript
// Before (WRONG - expected pr-17-vikingeventmgmt.onrender.com)
const prPreviewPattern = /^pr-\d+-vikings?-?eventmgmt(-mobile)?\.onrender\.com$/;

// After (CORRECT - matches vikingeventmgmt-pr-17.onrender.com)  
const prPreviewPattern = /^vikingeventmgmt-pr-\d+\.onrender\.com$/;
```

**Updated test case** to use correct format:
```javascript
// Before
.get('/oauth/callback?frontend_url=https://pr-123-vikings-eventmgmt.onrender.com');

// After  
.get('/oauth/callback?frontend_url=https://vikingeventmgmt-pr-123.onrender.com');
```

### Testing & Validation

#### ✅ Pattern Testing
- **Accepts actual format**: `vikingeventmgmt-pr-17.onrender.com` ✅
- **Rejects old format**: `pr-17-vikingeventmgmt.onrender.com` ❌  
- **Rejects malicious domains**: `evil.com` ❌

#### ✅ Test Suite
- All existing backend tests pass
- Security tests validate PR preview URL acceptance
- OAuth callback tests verify redirect behavior

#### ✅ Real-World Testing Ready
- Pattern now matches actual Render.com PR preview URLs
- Ready to test with current PR preview: `https://vikingeventmgmt-pr-17.onrender.com`

### Impact

**Before**: PR preview users → OAuth → Redirected to production ❌
**After**: PR preview users → OAuth → Stay on PR preview ✅

### Files Changed

- **`server.js`**: Fixed URL validation pattern (line 76)
- **`__tests__/security.test.js`**: Updated test to use correct format

### Related Issues

This resolves the issue discovered during testing of PR #17 where the member detail popup feature couldn't be properly tested on PR previews due to OAuth redirects to production.

### Deployment Impact

- **Zero breaking changes** - Only fixes broken functionality
- **Backward compatible** - Production and localhost still work
- **Security maintained** - Still rejects malicious domains
- **Immediate effect** - PR previews will work correctly after backend deployment

🤖 Generated with [Claude Code](https://claude.ai/code)