### PR TITLE
Fix: Sentry CLI token format and authentication

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,6 +1,9 @@
-[auth]
-token=sntrys_eyJpYXQiOjE3MjMxNjcyOTAuNjU3NzE3LCJ1cmwiOiJodHRwczovL3NlbnRyeS5pbyIsInJlZ2lvbl91cmwiOiJodHRwczovL3VzLnNlbnRyeS5pbyIsIm9yZyI6IndhbHRvbi12aWtpbmdzIn0=_+vPOYbPqhWGaRAb1e3Cpt3EQOzYBf1uHrsR/2R9HW8
-
 [defaults]
 org=walton-vikings
 project=nodejs-api-backend
+
+[auth]
+token='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'
+
+# Optional - specify your Sentry URL if using self-hosted
+# url=https://de.sentry.io


### PR DESCRIPTION
## Summary
- Fix Sentry CLI authentication errors (401 Invalid org token)
- Align backend Sentry configuration with working frontend setup
- Enable proper release management and deployment tracking

## Root Cause
The backend was using an incorrect Sentry token format and configuration structure, causing all Sentry CLI commands to fail with 401 authentication errors.

## Technical Changes
- **Token Format**: Switch from `sntrys_` format to working `sntryu_` format
- **Configuration Structure**: Match frontend `.sentryclirc` layout
- **URL Handling**: Comment out explicit URL to use automatic region detection
- **Token Alignment**: Use same working token as frontend

## Validation
- ✅ `npm run release:create` - Successfully creates Sentry releases
- ✅ `npm run release:finalize` - Successfully finalizes releases  
- ✅ Backend release v1.1.0 created and tracked in Sentry
- ✅ Authentication now working for all Sentry CLI operations

## Impact
- Enables automatic issue resolution tracking when releases fix production problems
- Provides deployment visibility and release management in Sentry dashboard
- Completes the comprehensive release management system for the backend
- Brings backend Sentry integration to parity with frontend

## Testing
Verified Sentry CLI commands now work correctly:
```bash
npm run release:create    # ✅ Created release vikings-osm-backend@1.1.0
npm run release:finalize  # ✅ Finalized release successfully
```

🤖 Generated with [Claude Code](https://claude.ai/code)