### PR TITLE
Document express endpoints with jsdoc

### DIFF
--- a/controllers/osm.js
+++ b/controllers/osm.js
@@ -23,7 +23,19 @@ const log = logger || fallbackLogger;
 // Import existing complex functions that need custom handling
 const { transformMemberGridData } = require('./osm-legacy');
 
-// Rate limit status endpoint (kept as-is since it's unique)
+/**
+ * Monitoring: Get current backend and OSM API rate-limit status for this session.
+ *
+ * @tags Monitoring
+ * @route GET /rate-limit-status
+ * @returns {object} 200 - Rate limit info
+ * @example Success response
+ * {
+ *   "backend": { "limit": 100, "remaining": 100, "resetTime": 1736443200000, "window": "per minute" },
+ *   "osm": { "limit": 1000, "remaining": 742, "resetTime": 1736446800000, "window": "per hour", "available": true },
+ *   "timestamp": 1736443185000
+ * }
+ */
 const getRateLimitStatus = (req, res) => {
   const sessionId = getSessionId(req);
     
@@ -64,46 +76,213 @@ const getRateLimitStatus = (req, res) => {
   });
 };
 
-// Simple endpoints using our factories (reduces ~400 lines to ~10 lines)
+/**
+ * OSM: Get terms (sections' term list).
+ *
+ * Proxies the OSM API `action=getTerms`.
+ *
+ * @tags OSM
+ * @route GET /get-terms
+ * @header Authorization {string} - Bearer OSM access token
+ * @returns {object} 200 - Terms array and OSM rate-limit headers
+ * @returns {object} 401 - When missing/invalid token
+ * @example Success response
+ * {
+ *   "terms": [
+ *     { "termid": 12345, "name": "Autumn 2024", "start": "2024-09-01", "end": "2024-12-15" },
+ *     { "termid": 12346, "name": "Spring 2025", "start": "2025-01-10", "end": "2025-04-01" }
+ *   ],
+ *   "rateLimit": { "limit": 1000, "remaining": 998, "reset": 1736446800 }
+ * }
+ * @example Error response (unauthorized)
+ * { "error": "Access token is required in Authorization header" }
+ */
 const getTerms = osmEndpoints.getTerms();
+
+/**
+ * OSM: Get section configuration.
+ *
+ * @tags OSM
+ * @route GET /get-section-config
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - OSM section id
+ * @returns {object} 200 - Configuration for the given section
+ * @example Success response
+ * { "sectionid": 321, "name": "Vikings Scouts", "meeting_night": "Mon", "age_range": "10-14" }
+ * @example Error response (missing param)
+ * { "error": "Missing required parameters: sectionid" }
+ */
 const getSectionConfig = osmEndpoints.getSectionConfig();
+
+/**
+ * OSM: Get user roles for the authenticated account.
+ *
+ * @tags OSM
+ * @route GET /get-user-roles
+ * @header Authorization {string}
+ * @returns {object} 200 - Roles info
+ * @example Success response
+ * { "roles": [ { "sectionid": 321, "role": "Leader" } ] }
+ * @example Error response (unauthorized)
+ * { "error": "Access token is required in Authorization header" }
+ */
 const getUserRoles = osmEndpoints.getUserRoles();
+
+/**
+ * OSM: Get events for a section and term.
+ *
+ * Dates are normalized: we include original UK format and ISO fields, and convert main field to mm/dd/yyyy for JS.
+ *
+ * @tags OSM
+ * @route GET /get-events
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.termid - Term id
+ * @returns {object} 200 - Events list with normalized dates
+ * @example Success response
+ * { "items": [ { "eventid": 9901, "name": "Night Hike", "date": "10/15/2024", "date_original": "15/10/2024", "date_iso": "2024-10-15" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, termid" }
+ */
 const getEvents = osmEndpoints.getEvents();
+
+/**
+ * OSM: Get attendance list for an event.
+ *
+ * @tags OSM
+ * @route GET /get-event-attendance
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.termid - Term id
+ * @param {string|number} query.eventid - Event id
+ * @returns {object} 200 - Attendance details
+ * @example Success response
+ * { "eventid": 9901, "attendees": [ { "scoutid": 555, "name": "Alex Johnson", "status": "Yes" }, { "scoutid": 556, "name": "Riley Park", "status": "No" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, termid, eventid" }
+ */
 const getEventAttendance = osmEndpoints.getEventAttendance();
+
+/**
+ * OSM: Get detailed event summary.
+ *
+ * @tags OSM
+ * @route GET /get-event-summary
+ * @header Authorization {string}
+ * @param {string|number} query.eventid - Event id
+ * @returns {object} 200 - Event summary structure
+ * @example Success response
+ * { "event": { "id": 9901, "name": "Night Hike", "location": "Hillside Trail" }, "stats": { "yes": 18, "no": 3, "maybe": 2 } }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: eventid" }
+ */
 const getEventSummary = osmEndpoints.getEventSummary();
+
+/**
+ * OSM: Get an individual member's contact details.
+ *
+ * @tags OSM
+ * @route GET /get-contact-details
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.scoutid - Member id
+ * @returns {object} 200 - Contact details
+ * @example Success response
+ * { "scoutid": 555, "name": "Alex Johnson", "primary_contact": { "name": "Sam Johnson", "relation": "Parent", "phone": "+44 7700 900123" } }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, scoutid" }
+ */
 const getContactDetails = osmEndpoints.getContactDetails();
+
+/**
+ * OSM: Get list of members for a section and term.
+ *
+ * @tags OSM
+ * @route GET /get-list-of-members
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.termid - Term id
+ * @param {string} query.section - Section type (e.g., "scouts")
+ * @returns {object} 200 - Members list
+ * @example Success response
+ * { "items": [ { "scoutid": 555, "name": "Alex Johnson" }, { "scoutid": 556, "name": "Riley Park" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, termid, section" }
+ */
 const getListOfMembers = osmEndpoints.getListOfMembers();
+
+/**
+ * OSM: Get FlexiRecord entries for a section.
+ *
+ * @tags OSM
+ * @route GET /get-flexi-records
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {boolean} [query.archived] - Optional; include archived records
+ * @returns {object} 200 - Flexi records metadata
+ * @example Success response
+ * { "records": [ { "flexirecordid": 42, "name": "Badges", "fields": ["f_1","f_2"] } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid" }
+ */
 const getFlexiRecords = osmEndpoints.getFlexiRecords();
+
+/**
+ * OSM: Get FlexiRecord structure/columns for a term.
+ *
+ * @tags OSM
+ * @route GET /get-flexi-structure
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.flexirecordid - Flexi record id
+ * @param {string|number} query.termid - Term id
+ * @returns {object} 200 - Structure fields/columns
+ * @example Success response
+ * { "columns": [ { "id": "f_1", "label": "Permission Slip" }, { "id": "f_2", "label": "Paid" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, flexirecordid, termid" }
+ */
 const getFlexiStructure = osmEndpoints.getFlexiStructure();
+
+/**
+ * OSM: Get a single FlexiRecord's data.
+ *
+ * @tags OSM
+ * @route GET /get-single-flexi-record
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.flexirecordid - Flexi record id
+ * @param {string|number} query.termid - Term id
+ * @returns {object} 200 - Record rows/values
+ * @example Success response
+ * { "rows": [ { "scoutid": 555, "f_1": "Yes", "f_2": "No" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, flexirecordid, termid" }
+ */
 const getSingleFlexiRecord = osmEndpoints.getSingleFlexiRecord();
-const getStartupData = osmEndpoints.getStartupData();
 
-// Complex endpoints that need custom logic
-const getMembersGrid = createOSMApiHandler('getMembersGrid', {
-  method: 'POST',
-  requiredParams: ['section_id', 'term_id'],
-  buildUrl: (_req) => 'https://www.onlinescoutmanager.co.uk/ext/members/contact/grid/?action=getMembers',
-  buildRequestOptions: (req, access_token) => {
-    const requestBody = new URLSearchParams({
-      section_id: req.body.section_id,
-      term_id: req.body.term_id,
-    });
-    
-    return {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${access_token}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: requestBody,
-    };
-  },
-  processResponse: (data, _req) => {
-    // Apply the existing transformation logic
-    return transformMemberGridData(data);
-  },
-});
-
+/**
+ * OSM: Update a single FlexiRecord field for one member.
+ *
+ * value can be an empty string to clear a field. `columnid` must match pattern `f_<number>`.
+ *
+ * @tags OSM
+ * @route POST /update-flexi-record
+ * @header Authorization {string}
+ * @param {string|number} body.sectionid - Section id
+ * @param {string|number} body.scoutid - Member id
+ * @param {string|number} body.flexirecordid - Flexi record id
+ * @param {string} body.columnid - Field id (e.g., f_1)
+ * @param {string} body.value - New value; can be empty to clear
+ * @param {string|number} body.termid - Term id
+ * @param {string} body.section - Section type (e.g., "scouts")
+ * @returns {object} 200 - OSM update result
+ * @returns {object} 400 - Validation error
+ * @example Success response
+ * { "success": true, "updated": { "scoutid": 555, "column": "f_1", "value": "Completed" } }
+ * @example Error response
+ * { "error": "Missing required parameter: value (can be empty string to clear field)" }
+ */
 const updateFlexiRecord = createOSMApiHandler('updateFlexiRecord', {
   method: 'POST',
   requiredParams: [], // Custom validation handles all parameters
@@ -170,6 +349,22 @@ const updateFlexiRecord = createOSMApiHandler('updateFlexiRecord', {
   },
 });
 
+/**
+ * OSM: Bulk update a FlexiRecord field for multiple members.
+ *
+ * @tags OSM
+ * @route POST /multi-update-flexi-record
+ * @header Authorization {string}
+ * @param {string|number} body.sectionid - Section id
+ * @param {Array<number>} body.scouts - Array of member ids (non-empty)
+ * @param {string} body.value - Value to set
+ * @param {string} body.column - Field id (e.g., f_2)
+ * @param {string|number} body.flexirecordid - Flexi record id
+ * @returns {object} 200 - Bulk update result
+ * @returns {object} 400 - Validation error
+ * @example Error response
+ * { "error": "scouts must be an array" }
+ */
 const multiUpdateFlexiRecord = createOSMApiHandler('multiUpdateFlexiRecord', {
   method: 'POST',
   requiredParams: ['sectionid', 'scouts', 'value', 'column', 'flexirecordid'],
@@ -204,6 +399,58 @@ const multiUpdateFlexiRecord = createOSMApiHandler('multiUpdateFlexiRecord', {
       },
       body: requestBody,
     };
+  },
+});
+
+/**
+ * OSM: Get startup data payload used by OSM web app (parsed from JS to JSON).
+ *
+ * @tags OSM
+ * @route GET /get-startup-data
+ * @header Authorization {string}
+ * @returns {object} 200 - Startup JSON payload
+ * @returns {object} 429 - When OSM rate limit is exceeded
+ * @example Error response (rate limited)
+ * { "error": "OSM API rate limit exceeded", "message": "Please wait before making more requests" }
+ */
+const getStartupData = osmEndpoints.getStartupData();
+
+/**
+ * OSM: Get members grid (transformed) for a section and term.
+ *
+ * @tags OSM
+ * @route POST /get-members-grid
+ * @header Authorization {string}
+ * @param {string|number} body.section_id - Section id
+ * @param {string|number} body.term_id - Term id
+ * @returns {object} 200 - Grid with column definitions and rows (transformed)
+ * @example Success response
+ * { "columns": [ { "key": "name", "label": "Name" } ], "rows": [ { "scoutid": 555, "name": "Alex Johnson" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: section_id, term_id" }
+ */
+const getMembersGrid = createOSMApiHandler('getMembersGrid', {
+  method: 'POST',
+  requiredParams: ['section_id', 'term_id'],
+  buildUrl: (_req) => 'https://www.onlinescoutmanager.co.uk/ext/members/contact/grid/?action=getMembers',
+  buildRequestOptions: (req, access_token) => {
+    const requestBody = new URLSearchParams({
+      section_id: req.body.section_id,
+      term_id: req.body.term_id,
+    });
+    
+    return {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: requestBody,
+    };
+  },
+  processResponse: (data, _req) => {
+    // Apply the existing transformation logic
+    return transformMemberGridData(data);
   },
 });
 

--- a/server.js
+++ b/server.js
@@ -235,17 +235,32 @@ app.use(backendRateLimit); // Apply rate limiting middleware to all routes
 
 // Backend API Documentation endpoints - Clean setup
 const swaggerUi = require('swagger-ui-express');
+/**
+ * Docs: Interactive Swagger UI for backend endpoints.
+ * @tags Docs
+ * @route GET /backend-docs
+ * @returns {text/html} 200 - Rendered Swagger UI
+ */
 app.use('/backend-docs', swaggerUi.serve);
 app.get('/backend-docs', swaggerUi.setup(frontendApiDocs.specs, {
   customSiteTitle: 'Vikings OSM Backend API Documentation',
   explorer: false,
 }));
 
-
-// Serve Backend API OpenAPI spec as JSON
+/**
+ * Docs: Backend OpenAPI spec JSON.
+ * @tags Docs
+ * @route GET /backend-docs.json
+ * @returns {object} 200 - OpenAPI JSON
+ */
 app.get('/backend-docs.json', createJsonSpecEndpoint(frontendApiDocs.specs));
 
-// Keep old endpoint for backward compatibility
+/**
+ * Docs: Legacy OpenAPI spec JSON (backward compatibility).
+ * @tags Docs
+ * @route GET /api-docs.json
+ * @returns {object} 200 - OpenAPI JSON (same as /backend-docs.json)
+ */
 app.get('/api-docs.json', createJsonSpecEndpoint(frontendApiDocs.specs));
 
 // OSM API Documentation endpoints - DISABLED to fix conflicts
@@ -389,7 +404,23 @@ const apiMonitoringMiddleware = (req, res, next) => {
 // Apply API monitoring middleware to all routes
 app.use(apiMonitoringMiddleware);
 
-// Enhanced health endpoint with Sentry metrics
+/**
+ * Health: Basic service and environment status.
+ *
+ * Useful for uptime checks and quick diagnostics. Includes token stats and memory snapshot.
+ *
+ * @tags Health
+ * @route GET /health
+ * @returns {object} 200 - Service status, environment, and lightweight metrics
+ * @example Success response
+ * {
+ *   "status": "healthy",
+ *   "timestamp": "2025-01-09T12:34:56.789Z",
+ *   "uptime": "3600 seconds",
+ *   "environment": "development",
+ *   "tokenStats": { "total": 2, "active": 2, "expired": 0 }
+ * }
+ */
 app.get('/health', (req, res) => {
   const { getTokenStats } = require('./controllers/auth');
   const stats = getTokenStats();
@@ -471,7 +502,14 @@ app.get('/health', (req, res) => {
   res.json(healthData);
 });
 
-// Token management endpoint for debugging (remove in production)
+/**
+ * Admin: Inspect in-memory tokens (disabled in production).
+ *
+ * @tags Admin
+ * @route GET /admin/tokens
+ * @returns {object} 200 - Summary and redacted token list
+ * @returns {object} 403 - When NODE_ENV=production
+ */
 app.get('/admin/tokens', (req, res) => {
   if (process.env.NODE_ENV === 'production') {
     return res.status(403).json({ error: 'Admin endpoints disabled in production' });
@@ -509,7 +547,14 @@ app.get('/admin/tokens', (req, res) => {
   });
 });
 
-// Token cleanup endpoint
+/**
+ * Admin: Remove expired tokens from memory (disabled in production).
+ *
+ * @tags Admin
+ * @route POST /admin/tokens/cleanup
+ * @returns {object} 200 - Cleanup summary
+ * @returns {object} 403 - When NODE_ENV=production
+ */
 app.post('/admin/tokens/cleanup', (req, res) => {
   if (process.env.NODE_ENV === 'production') {
     return res.status(403).json({ error: 'Admin endpoints disabled in production' });
@@ -532,7 +577,14 @@ app.post('/admin/tokens/cleanup', (req, res) => {
   });
 });
 
-// Clear all tokens endpoint
+/**
+ * Admin: Clear all tokens from memory (disabled in production).
+ *
+ * @tags Admin
+ * @route POST /admin/tokens/clear
+ * @returns {object} 200 - Clear summary
+ * @returns {object} 403 - When NODE_ENV=production
+ */
 app.post('/admin/tokens/clear', (req, res) => {
   if (process.env.NODE_ENV === 'production') {
     return res.status(403).json({ error: 'Admin endpoints disabled in production' });
@@ -548,24 +600,121 @@ app.post('/admin/tokens/clear', (req, res) => {
   });
 });
 
-// OSM API proxy endpoints (with rate limiting)
+/**
+ * OSM: Terms proxy.
+ * @tags OSM
+ * @route GET /get-terms
+ */
 app.get('/get-terms', osmController.getTerms); // Updated to GET
+
+/**
+ * OSM: Section configuration proxy.
+ * @tags OSM
+ * @route GET /get-section-config
+ */
 app.get('/get-section-config', osmController.getSectionConfig); // Updated to GET
+
+/**
+ * OSM: User roles proxy.
+ * @tags OSM
+ * @route GET /get-user-roles
+ */
 app.get('/get-user-roles', osmController.getUserRoles); // Updated to GET
+
+/**
+ * OSM: Events proxy.
+ * @tags OSM
+ * @route GET /get-events
+ */
 app.get('/get-events', osmController.getEvents); // Updated to GET
+
+/**
+ * OSM: Event attendance proxy.
+ * @tags OSM
+ * @route GET /get-event-attendance
+ */
 app.get('/get-event-attendance', osmController.getEventAttendance);
+
+/**
+ * OSM: Event summary proxy.
+ * @tags OSM
+ * @route GET /get-event-summary
+ */
 app.get('/get-event-summary', osmController.getEventSummary);
+
+/**
+ * OSM: Contact details proxy.
+ * @tags OSM
+ * @route GET /get-contact-details
+ */
 app.get('/get-contact-details', osmController.getContactDetails);
+
+/**
+ * OSM: Members list proxy.
+ * @tags OSM
+ * @route GET /get-list-of-members
+ */
 app.get('/get-list-of-members', osmController.getListOfMembers);
+
+/**
+ * OSM: Flexi records proxy.
+ * @tags OSM
+ * @route GET /get-flexi-records
+ */
 app.get('/get-flexi-records', osmController.getFlexiRecords);
+
+/**
+ * OSM: Flexi structure proxy.
+ * @tags OSM
+ * @route GET /get-flexi-structure
+ */
 app.get('/get-flexi-structure', osmController.getFlexiStructure);
+
+/**
+ * OSM: Single flexi record proxy.
+ * @tags OSM
+ * @route GET /get-single-flexi-record
+ */
 app.get('/get-single-flexi-record', osmController.getSingleFlexiRecord);
+
+/**
+ * OSM: Update single flexi record.
+ * @tags OSM
+ * @route POST /update-flexi-record
+ */
 app.post('/update-flexi-record', osmController.updateFlexiRecord);
+
+/**
+ * OSM: Bulk update flexi record.
+ * @tags OSM
+ * @route POST /multi-update-flexi-record
+ */
 app.post('/multi-update-flexi-record', osmController.multiUpdateFlexiRecord);
+
+/**
+ * OSM: Startup data proxy.
+ * @tags OSM
+ * @route GET /get-startup-data
+ */
 app.get('/get-startup-data', osmController.getStartupData);
+
+/**
+ * OSM: Members grid (transformed).
+ * @tags OSM
+ * @route POST /get-members-grid
+ */
 app.post('/get-members-grid', osmController.getMembersGrid);
 
-// Sentry test endpoint
+/**
+ * Monitoring: Sentry test helper.
+ *
+ * Use `?type=error|message|exception` to trigger different behaviors.
+ *
+ * @tags Monitoring
+ * @route GET /test-sentry
+ * @param {string} [query.type] - One of: error, message, exception
+ * @returns {object} 200 - Guidance or confirmation
+ */
 app.get('/test-sentry', createTestEndpoint({
   'error': (_req, _res) => {
     throw new Error('Test error for Sentry - this is expected!');
@@ -597,7 +746,55 @@ app.get('/test-sentry', createTestEndpoint({
   },
 }, 'type', 'default'));
 
-// Rate limiting test endpoint for development
+/**
+ * Monitoring: Sentry test helper.
+ *
+ * Use `?type=error|message|exception` to trigger different behaviors.
+ *
+ * @tags Monitoring
+ * @route GET /test-sentry
+ * @param {string} [query.type] - One of: error, message, exception
+ * @returns {object} 200 - Guidance or confirmation
+ */
+app.get('/test-sentry', createTestEndpoint({
+  'error': (_req, _res) => {
+    throw new Error('Test error for Sentry - this is expected!');
+  },
+  'message': (req, res) => {
+    if (Sentry) {
+      Sentry.captureMessage('Test message from backend', 'info');
+    }
+    res.json({ message: 'Test message sent to Sentry' });
+  },
+  'exception': (req, res) => {
+    if (Sentry) {
+      Sentry.captureException(new Error('Test exception for Sentry'));
+    }
+    res.json({ message: 'Test exception sent to Sentry' });
+  },
+  'default': (req, res) => {
+    res.json({ 
+      message: 'Sentry test endpoint',
+      usage: '?type=error|message|exception',
+      sentryEnabled: !!Sentry && !!process.env.SENTRY_DSN,
+      debug: {
+        sentryObject: !!Sentry,
+        dsn: process.env.SENTRY_DSN ? 'Set' : 'Missing',
+        nodeEnv: process.env.NODE_ENV,
+        testEnv: process.env.NODE_ENV === 'test',
+      },
+    });
+  },
+}, 'type', 'default'));
+
+/**
+ * Monitoring: Rate-limit test helper for development.
+ *
+ * @tags Monitoring
+ * @route GET /test-rate-limits
+ * @param {string} [query.type] - backend-stress | osm-simulation
+ * @returns {object} 200 - Guidance or simulation
+ */
 app.get('/test-rate-limits', createTestEndpoint({
   'backend-stress': (req, res) => {
     // This will trigger backend rate limiting after multiple requests
@@ -638,7 +835,13 @@ app.get('/test-rate-limits', createTestEndpoint({
   },
 }));
 
-// Add OAuth environment validation endpoint for debugging
+/**
+ * OAuth: Debug current environment and token storage.
+ *
+ * @tags OAuth
+ * @route GET /oauth/debug
+ * @returns {object} 200 - Environment and token diagnostics
+ */
 app.get('/oauth/debug', (req, res) => {
   const { getTokenStats } = require('./controllers/auth');
   const { getSessionId } = require('./middleware/rateLimiting');
@@ -682,7 +885,15 @@ app.get('/oauth/debug', (req, res) => {
   });
 });
 
-// Frontend URL detection test endpoint
+/**
+ * Utility: Inspect how the frontend URL is detected.
+ *
+ * @tags Utility
+ * @route GET /test-frontend-url
+ * @param {string} [query.state] - dev to simulate dev detection
+ * @param {string} [query.frontend_url] - Explicit override
+ * @returns {object} 200 - Detection details and scenarios
+ */
 app.get('/test-frontend-url', (req, res) => {
   const detectedUrl = getFrontendUrl(req, { enableLogging: true });
   
@@ -847,7 +1058,23 @@ const getUrlDetectionMethod = (req) => {
   return 'Default Fallback (Production)';
 };
 
-// OAuth callback route to handle the authorization code from OSM
+/**
+ * OAuth: Authorization callback handler from OSM.
+ *
+ * Exchanges the code for a token, stores it against the session, then redirects back to the frontend.
+ *
+ * @tags OAuth
+ * @route GET /oauth/callback
+ * @param {string} query.code - Authorization code from OSM
+ * @param {string} [query.state] - State echo from original request
+ * @param {string} [query.error] - Error from OSM if the user denied authorization
+ * @param {string} [query.frontend_url] - Optional, validated redirect target
+ * @returns {void} 302 - Redirect to frontend with optional error query param
+ * @example Redirect on success
+ * 302 Location: https://vikingeventmgmt.onrender.com
+ * @example Redirect on error
+ * 302 Location: https://vikingeventmgmt.onrender.com?error=access_denied
+ */
 app.get('/oauth/callback', async (req, res) => {
   try {
     const { code, state, error } = req.query;


### PR DESCRIPTION
Add JSDoc/Swagger-style comments to Express endpoints to enable OpenAPI documentation generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-39aa6932-1682-47ab-8ad8-34637313b4e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39aa6932-1682-47ab-8ad8-34637313b4e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

