### PR TITLE
fix: remove OAuth client ID from frontend for security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ src/
 
 # Real OSM data examples
 osm_examples/
+
+# Task Master files
+.taskmaster/


### PR DESCRIPTION
- Remove VITE_OAUTH_CLIENT_ID from required environment variables
- Update generateOAuthUrl() to redirect to backend /oauth/login endpoint
- Remove client ID validation and client ID from config export
- OAuth client ID now handled server-side for enhanced security
- Prevents OAuth client credentials from being exposed in frontend JavaScript
- Frontend now delegates OAuth URL construction to backend

🤖 Generated with [Claude Code](https://claude.ai/code)