### PR TITLE
Fix: Add new flexi record endpoints to server startup logs

### DIFF
--- a/utils/serverHelpers.js
+++ b/utils/serverHelpers.js
@@ -141,6 +141,8 @@ const logAvailableEndpoints = () => {
   console.log('- GET /get-flexi-structure');
   console.log('- GET /get-single-flexi-record');
   console.log('- POST /update-flexi-record');
+  console.log('- POST /create-flexi-record');
+  console.log('- POST /add-flexi-column');
   console.log('- POST /get-members-grid');
 };
 


### PR DESCRIPTION
## Summary
- Add missing FlexiRecord management endpoints to server startup logging
- Ensures /create-flexi-record and /add-flexi-column endpoints are visible in server logs
- Improves visibility of newly added API endpoints for debugging and monitoring

## Changes
- Updated utils/serverHelpers.js to include the two new endpoints in logAvailableEndpoints()
- Server startup now properly lists all available endpoints

## Before
```
OSM API Proxy:
- POST /update-flexi-record
- POST /get-members-grid
```

## After  
```
OSM API Proxy:
- POST /update-flexi-record
- POST /create-flexi-record  ← NEW
- POST /add-flexi-column     ← NEW
- POST /get-members-grid
```

This ensures the server startup logs correctly reflect all available endpoints, making it easier to verify that the new FlexiRecord management functionality is active.

🤖 Generated with [Claude Code](https://claude.ai/code)