### PR TITLE
Performance: Increase rate limit to 10 requests per second

### DIFF
--- a/middleware/rateLimiting.js
+++ b/middleware/rateLimiting.js
@@ -17,7 +17,7 @@ const MAX_REQUESTS_PER_WINDOW = process.env.NODE_ENV === 'test' ? 1000 : 100; //
 
 // Per-second rate limiting to prevent burst requests
 const BACKEND_RATE_LIMIT_SECOND = 1000; // 1 second window
-const MAX_REQUESTS_PER_SECOND = process.env.NODE_ENV === 'test' ? 100 : 5; // 5 req/sec for development and production
+const MAX_REQUESTS_PER_SECOND = process.env.NODE_ENV === 'test' ? 100 : 10; // 10 req/sec for development and production
 
 // Per-hour rate limiting to stay under OSM's 1000/hour limit
 const BACKEND_RATE_LIMIT_HOUR = 3600000; // 1 hour window (60 * 60 * 1000)

--- a/utils/serverHelpers.js
+++ b/utils/serverHelpers.js
@@ -141,6 +141,8 @@ const logAvailableEndpoints = () => {
   console.log('- GET /get-flexi-structure');
   console.log('- GET /get-single-flexi-record');
   console.log('- POST /update-flexi-record');
+  console.log('- POST /create-flexi-record');
+  console.log('- POST /add-flexi-column');
   console.log('- POST /get-members-grid');
 };
 


### PR DESCRIPTION
## Summary

Increases the backend rate limit from 5 to 10 requests per second to improve data loading performance.

## Changes Made

- **Updated **: 5 → 10 requests per second
- **Maintains existing limits**: 100/minute and 900/hour remain unchanged
- **Preserves OSM API protection**: Still well under OSM's limits

## Performance Impact

- **Faster data loading**: Allows twice as many burst requests
- **No 429 errors**: Tested successfully with improved performance  
- **Combined with frontend optimizations**: Works with reduced frontend delays for optimal speed

## Testing

✅ Tested with multiple API calls - no rate limit errors
✅ Maintains proper rate limiting behavior when exceeded
✅ OSM API limits still respected and monitored

## Risk Assessment

- **Low risk**: Still conservative compared to OSM's actual limits
- **Monitored**: Rate limiting logging and Sentry tracking remain active
- **Reversible**: Easy to roll back if issues arise

🤖 Generated with [Claude Code](https://claude.ai/code)