### PR TITLE
feat: redirect iOS OAuth callback to vikings:// custom scheme

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -547,10 +547,34 @@ describe('OAuth Callback Advanced Testing', () => {
         code: 'test-code',
         state: 'retry-test',
       });
-      
+
     expect(response.status).toBe(302);
     expect(response.headers.location).toContain('access_token=retry-success-token');
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('redirects iOS clients to vikings:// custom scheme when state has :ios suffix', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        access_token: 'ios-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      }),
+    });
+
+    const response = await request(app)
+      .get('/oauth/callback')
+      .query({
+        code: 'test-code',
+        state: 'prod:ios',
+      });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toMatch(/^vikings:\/\/oauth-callback\?/);
+    expect(response.headers.location).toContain('access_token=ios-token');
+    expect(response.headers.location).toContain('token_type=Bearer');
+    expect(response.headers.location).toContain('expires_in=3600');
   });
 });
 

--- a/config/sentry.js
+++ b/config/sentry.js
@@ -49,7 +49,20 @@ try {
   Sentry = null;
 }
 
-module.exports = { 
-  Sentry, 
-  logger: Sentry?.logger || null, 
+// No-op fallback so callers can do `logger.info(...)` without null-checks
+// when Sentry is unavailable (test env, missing package, etc.)
+const noopLogger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  fmt: (strings, ...values) =>
+    strings.reduce((acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ''), ''),
+};
+
+module.exports = {
+  Sentry,
+  logger: Sentry?.logger || noopLogger,
 };

--- a/server.js
+++ b/server.js
@@ -1428,9 +1428,29 @@ app.get('/oauth/callback', async (req, res) => {
     // Log successful token exchange
     osmHealthLogger.logTokenExchange(true, tokenData);
 
-    // Redirect to frontend with token as URL parameter (original working approach)
-    // This allows the frontend to store the token in sessionStorage on the correct domain
-    const redirectUrl = `${frontendUrl}/?access_token=${tokenData.access_token}&token_type=${tokenData.token_type || 'Bearer'}`;
+    const stateParts = (typeof state === 'string' ? state : '').split(':');
+    const platform = (stateParts[1] || 'web').toLowerCase();
+    const isIOS = platform === 'ios';
+
+    let redirectUrl;
+    if (isIOS) {
+      const iosParams = new URLSearchParams({
+        access_token: tokenData.access_token,
+        token_type: tokenData.token_type || 'Bearer',
+      });
+      if (tokenData.expires_in !== undefined && tokenData.expires_in !== null) {
+        iosParams.set('expires_in', String(tokenData.expires_in));
+      }
+      redirectUrl = `vikings://oauth-callback?${iosParams.toString()}`;
+      logger.info('Redirecting iOS client to custom URL scheme', {
+        platform,
+        section: 'oauth-callback-ios-deeplink',
+        endpoint: '/oauth/callback',
+        timestamp: new Date().toISOString(),
+      });
+    } else {
+      redirectUrl = `${frontendUrl}/?access_token=${tokenData.access_token}&token_type=${tokenData.token_type || 'Bearer'}`;
+    }
     oAuthCallbackLogger.logSuccessfulRedirect(redirectUrl);
     res.redirect(redirectUrl);
     

--- a/server.js
+++ b/server.js
@@ -1149,23 +1149,87 @@ const getUrlDetectionMethod = (req) => {
 };
 
 /**
+ * Parse the platform suffix from the OAuth state parameter.
+ *
+ * State may contain `&frontend_url=...` appended by /oauth/login, so we
+ * split on `&` first and only inspect the first segment. The first segment
+ * is `${env}:${platform}` (e.g. `prod:ios`, `dev:web`) or just `${env}`
+ * for legacy callers without platform support.
+ *
+ * Returns 'web' for empty/unknown values, with a warn log for any non-empty
+ * suffix that isn't recognised so future platform additions are noticed.
+ *
+ * @param {string|undefined} state
+ * @returns {'ios'|'web'}
+ */
+function parsePlatformFromState(state) {
+  const firstSegment = (typeof state === 'string' ? state : '').split('&')[0];
+  const stateParts = firstSegment.split(':');
+  const raw = (stateParts[1] || '').toLowerCase().trim();
+  if (!raw) return 'web';
+  if (raw === 'ios' || raw === 'web') return raw;
+  (logger?.warn || console.warn)('OAuth callback received with unrecognised platform suffix', {
+    rawPlatform: raw,
+    firstSegment,
+    state: typeof state === 'string' ? state.slice(0, 200) : null,
+    section: 'oauth-callback-unknown-platform',
+    endpoint: '/oauth/callback',
+  });
+  return 'web';
+}
+
+/**
+ * Build a platform-aware redirect URL.
+ *
+ * iOS clients receive `vikings://oauth-callback?...` so the Capacitor
+ * native app can intercept via the registered URL scheme. All other
+ * platforms get the standard HTTPS redirect to the frontend.
+ *
+ * @param {string} frontendUrl
+ * @param {boolean} isIOS
+ * @param {Record<string, string|number|undefined|null>} params
+ * @returns {string}
+ */
+function buildRedirectUrl(frontendUrl, isIOS, params) {
+  const search = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    search.set(k, typeof v === 'string' ? v : JSON.stringify(v));
+  }
+  if (isIOS) {
+    return `vikings://oauth-callback?${search.toString()}`;
+  }
+  return `${frontendUrl}/?${search.toString()}`;
+}
+
+/**
  * OAuth: Authorization callback handler from OSM.
  *
  * Exchanges the code for a token, stores it against the session, then redirects back to the frontend.
+ * iOS clients (state suffix `:ios`) receive `vikings://oauth-callback?...` instead of the HTTPS frontend
+ * URL so the Capacitor native app can intercept via the registered URL scheme.
  *
  * @tags OAuth
  * @route GET /oauth/callback
  * @param {string} query.code - Authorization code from OSM
- * @param {string} [query.state] - State echo from original request
+ * @param {string} [query.state] - State echo from original request, format `${env}:${platform}` (e.g. `prod:ios`)
  * @param {string} [query.error] - Error from OSM if the user denied authorization
- * @param {string} [query.frontend_url] - Optional, validated redirect target
- * @returns {void} 302 - Redirect to frontend with optional error query param
- * @example Redirect on success
- * 302 Location: https://vikingeventmgmt.onrender.com
- * @example Redirect on error
+ * @param {string} [query.frontend_url] - Optional, validated redirect target (web only)
+ * @returns {void} 302 - Redirect to frontend (web) or vikings:// (iOS) with optional error query param
+ * @example Web success
+ * 302 Location: https://vikingeventmgmt.onrender.com/?access_token=...
+ * @example iOS success
+ * 302 Location: vikings://oauth-callback?access_token=...
+ * @example Web error
  * 302 Location: https://vikingeventmgmt.onrender.com?error=access_denied
+ * @example iOS error
+ * 302 Location: vikings://oauth-callback?error=access_denied
  */
 app.get('/oauth/callback', async (req, res) => {
+  const platform = parsePlatformFromState(req.query.state);
+  const isIOS = platform === 'ios';
+  const frontendUrl = getFrontendUrl(req, {enableLogging: true});
+
   try {
     const { code, state, error } = req.query;
     
@@ -1194,20 +1258,25 @@ app.get('/oauth/callback', async (req, res) => {
     });
     
     oAuthCallbackLogger.logCallbackReceived(code, state, error, req);
-    
-    // Debug the frontend URL determination
-    const frontendUrl = getFrontendUrl(req, {enableLogging: true});
     oAuthCallbackLogger.logFrontendUrlDetermination(frontendUrl);
-    
-    
+
     if (error) {
-      console.error('OAuth error from OSM:', error);
-      return res.redirect(`${frontendUrl}?error=${error}`);
+      (logger?.error || console.error)('OAuth error returned from OSM', {
+        oauthError: error,
+        platform,
+        section: 'oauth-callback-osm-error',
+        endpoint: '/oauth/callback',
+      });
+      return res.redirect(buildRedirectUrl(frontendUrl, isIOS, { error }));
     }
-    
+
     if (!code) {
-      console.error('No authorization code received');
-      return res.redirect(`${frontendUrl}?error=no_code`);
+      (logger?.error || console.error)('No authorization code received from OSM', {
+        platform,
+        section: 'oauth-callback-no-code',
+        endpoint: '/oauth/callback',
+      });
+      return res.redirect(buildRedirectUrl(frontendUrl, isIOS, { error: 'no_code' }));
     }
 
     // Exchange authorization code for access token
@@ -1422,41 +1491,59 @@ app.get('/oauth/callback', async (req, res) => {
         endpoint: '/oauth/callback',
         timestamp: new Date().toISOString(),
       });
-      return res.redirect(`${frontendUrl}?error=token_exchange_failed&details=${encodeURIComponent(JSON.stringify(errorDetails))}`);
+      return res.redirect(buildRedirectUrl(frontendUrl, isIOS, {
+        error: 'token_exchange_failed',
+        details: errorDetails,
+      }));
     }
 
     // Log successful token exchange
     osmHealthLogger.logTokenExchange(true, tokenData);
 
-    const stateParts = (typeof state === 'string' ? state : '').split(':');
-    const platform = (stateParts[1] || 'web').toLowerCase();
-    const isIOS = platform === 'ios';
-
-    let redirectUrl;
-    if (isIOS) {
-      const iosParams = new URLSearchParams({
-        access_token: tokenData.access_token,
-        token_type: tokenData.token_type || 'Bearer',
-      });
-      if (tokenData.expires_in !== undefined && tokenData.expires_in !== null) {
-        iosParams.set('expires_in', String(tokenData.expires_in));
-      }
-      redirectUrl = `vikings://oauth-callback?${iosParams.toString()}`;
-      logger.info('Redirecting iOS client to custom URL scheme', {
+    if (!tokenData.access_token) {
+      (logger?.error || console.error)('Missing access_token at redirect-build (defensive guard)', {
         platform,
+        tokenKeys: Object.keys(tokenData || {}),
+        section: 'oauth-callback-missing-token-defensive',
+        endpoint: '/oauth/callback',
+      });
+      return res.redirect(buildRedirectUrl(frontendUrl, isIOS, {
+        error: 'missing_access_token',
+      }));
+    }
+
+    const redirectUrl = buildRedirectUrl(frontendUrl, isIOS, {
+      access_token: tokenData.access_token,
+      token_type: tokenData.token_type || 'Bearer',
+      expires_in: tokenData.expires_in !== undefined && tokenData.expires_in !== null
+        ? String(tokenData.expires_in)
+        : undefined,
+    });
+
+    if (isIOS) {
+      (logger?.info || console.info)('Redirecting iOS client to custom URL scheme', {
+        platform,
+        rawState: typeof state === 'string' ? state.slice(0, 200) : null,
+        hasExpiresIn: tokenData.expires_in !== undefined && tokenData.expires_in !== null,
         section: 'oauth-callback-ios-deeplink',
         endpoint: '/oauth/callback',
-        timestamp: new Date().toISOString(),
       });
-    } else {
-      redirectUrl = `${frontendUrl}/?access_token=${tokenData.access_token}&token_type=${tokenData.token_type || 'Bearer'}`;
     }
     oAuthCallbackLogger.logSuccessfulRedirect(redirectUrl);
     res.redirect(redirectUrl);
-    
-  } catch (error) {
-    console.error('OAuth callback error:', error);
-    res.redirect(`${getFrontendUrl(req)}?error=callback_error&details=${encodeURIComponent(error.message)}`);
+
+  } catch (caughtError) {
+    (logger?.error || console.error)('OAuth callback unhandled error', {
+      error: caughtError.message,
+      stack: caughtError.stack,
+      platform,
+      section: 'oauth-callback-unhandled',
+      endpoint: '/oauth/callback',
+    });
+    res.redirect(buildRedirectUrl(frontendUrl, isIOS, {
+      error: 'callback_error',
+      details: caughtError.message,
+    }));
   }
 });
 


### PR DESCRIPTION
## Summary

Companion to frontend PR **Walton-Viking-Scouts/VikingsEventMgmt#190** (closes frontend issue Walton-Viking-Scouts/VikingsEventMgmt#182).

iOS Capacitor users currently get stranded in Safari after authorizing with OSM — the WebView never receives the token. This PR detects iOS clients via the OAuth `state` parameter and redirects to a custom URL scheme so the native app receives the token via deep link.

## Convention (agreed with frontend)

The frontend's `generateOAuthUrl()` encodes the platform in the OAuth `state` parameter, format: `${env}:${platform}` (e.g. `prod:ios`, `dev:web`, `prod:android`). OSM round-trips state unchanged.

## Changes

### Initial commit (`0b54361`) — iOS-aware redirect
`server.js` — added iOS branch to the OAuth callback success path: redirect to `vikings://oauth-callback?access_token=...&token_type=...&expires_in=...` when `state` ends with `:ios`.

### Review-fix commit (`306893d`) — addresses all 5 findings from PR review

| Finding | Fix | Location |
|---|---|---|
| 🔴 **#1: iOS stranded on errors** | All 4 error redirects now route through `buildRedirectUrl()`. iOS clients get `vikings://oauth-callback?error=...` instead of being dumped into Safari. Platform/`isIOS`/`frontendUrl` computed BEFORE `try` so the outer `catch` can also use them. | `server.js:1228-1231, 1280-1300, 1494-1500, 1562-1572` |
| 🔴 **#2: State parsing collision with frontend_url channel** | `parsePlatformFromState()` splits state on `&` first, then `:`. Frontend_url-with-colons can never poison platform detection. | `server.js:1167-1185` |
| 🟠 **#3: Silent fallback on malformed iOS state** | `parsePlatformFromState` warns when state has a non-empty suffix that isn't `web`/`ios`. Falls back to web with a logged signal so misconfigured clients are diagnosable. | same helper |
| 🟡 **#4: Logging gaps** | iOS success log includes `rawState` (truncated to 200 chars) and `hasExpiresIn`. Outer catch uses structured `logger.error` instead of `console.error`. | `server.js:1538-1544, 1561-1567` |
| 🟡 **#5: Defensive token check** | Guard before building iOS URL — if `access_token` is somehow null despite earlier checks, redirect with `error=missing_access_token` instead of producing the literal string `'access_token=undefined'`. | `server.js:1517-1527` |

### Bonus: logger null-safety (`config/sentry.js`)

Replaced `logger: Sentry?.logger || null` with a no-op logger fallback. Test env was returning `null`, so every `logger.info()` call in the OAuth handler was throwing silently and falling through to the outer catch — the 50 "passing" tests with loose `.toContain(frontendUrl)` assertions were masquerading the crash. The 3 pre-existing failures B1 flagged as "unrelated" were actually consequences of this masquerade — strict assertions caught the divergence.

With the fallback, the actual handler logic now runs cleanly in tests.

## Backwards compatibility

State values without the `:platform` suffix (e.g. `state=prod` or legacy `state=prod&frontend_url=...`) default to `platform === 'web'` and follow the original redirect behaviour. **No breaking change to web clients.**

## Verification

```
npm test       → 54 passed, 0 failed (was 50 / 3 failed)
npm run lint   → 2 pre-existing trailing-comma errors in
                 controllers/osm-legacy.js (not introduced)
```

## Test plan

- [x] iOS happy-path test added (`state=prod:ios` → `vikings://oauth-callback?access_token=...`)
- [x] Existing web flow tests still pass (50 → 50, plus 3 fixed)
- [ ] **End-to-end with frontend PR**: real iOS device tap "Sign in" → SFSafariViewController → authorize → app receives token
- [ ] **Cancel flow on iOS**: dismiss SFSafariViewController → app stays on login (no token in storage)
- [ ] **Web flow on production**: sign in → standard HTTPS redirect → land authenticated
- [ ] **PR preview flow**: `state=prod&frontend_url=https://vikingeventmgmt-pr-N.onrender.com` → web redirect to that URL

## Risks

1. **OAuth `state` round-trip via OSM** — assumes OSM passes state back unchanged. If OSM strips/modifies, iOS detection fails and falls through to web redirect (now logged at warn). Verify on real device.
2. **Coexistence with existing `frontend_url`-in-state channel** — verified to coexist. State `prod:ios&frontend_url=https://...` works (split on `&` first, then `:`).

## Related

- Frontend PR: Walton-Viking-Scouts/VikingsEventMgmt#190
- Frontend issue: Walton-Viking-Scouts/VikingsEventMgmt#182

🤖 Generated with [Claude Code](https://claude.com/claude-code)