### PR TITLE
fix: allow Capacitor mobile WebView origins in CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -207,7 +207,7 @@ if (Sentry && process.env.SENTRY_DSN && process.env.NODE_ENV !== 'test') {
   console.log('⚠️ Sentry request handlers NOT added - Sentry:', !!Sentry, 'DSN:', !!process.env.SENTRY_DSN, 'ENV:', process.env.NODE_ENV);
 }
 
-// Dynamic CORS configuration to allow production, localhost, and specific PR previews
+// Dynamic CORS configuration to allow production, localhost, PR previews, and Capacitor mobile WebViews
 const allowedOrigins = [
   'https://vikings-eventmgmt.onrender.com',  // Production frontend (vanilla)
   'https://vikingeventmgmt.onrender.com',    // Production frontend (React mobile)
@@ -215,6 +215,8 @@ const allowedOrigins = [
   'http://localhost:3000',                   // Development frontend (vanilla - http)
   'https://localhost:3001',                  // Development frontend (React mobile)
   'http://localhost:3001',                   // Development frontend (React mobile - http)
+  'capacitor://localhost',                   // Capacitor iOS WebView
+  'https://localhost',                       // Capacitor Android WebView (default scheme)
 ];
 const prPreviewPattern = /^https:\/\/vikingeventmgmt-pr-\d+\.onrender\.com$/;
 


### PR DESCRIPTION
## Problem

iOS TestFlight build can sign in via OAuth (top-level navigation, not subject to CORS) but every subsequent API call fails with the opaque \`TypeError: Load failed\`. Confirmed in Sentry as **VIKING-EVENT-MGMT-FH** and **-FG** — fetches to \`/get-user-roles\` and \`/get-startup-data\` from origin \`capacitor://localhost\`, blocked at the CORS preflight.

## Root cause

Capacitor's iOS WebView serves the app from \`capacitor://localhost\` (Android default is \`https://localhost\`). Neither was in \`allowedOrigins\` (server.js:211-218).

## Fix

Add both Capacitor default schemes to \`allowedOrigins\`. One-line change.

## Verification

- \`npm test\` → 54 passed
- Sentry trace \`7c9871183f2f459b9f19b9c3ea7b6be2\` shows the offending requests
- OAuth flow already works (top-level navigation, not CORS-gated)

## Test plan

After merge + Northflank auto-deploy:
- [ ] iOS TestFlight: sign in → dashboard loads with sections + events (currently empty)
- [ ] Web flow unchanged
- [ ] PR preview origins still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)