### PR TITLE
fix: include photo_guid and pic in member grid transform

### DIFF
--- a/__tests__/transformMemberGridData.test.js
+++ b/__tests__/transformMemberGridData.test.js
@@ -1,0 +1,43 @@
+const { transformMemberGridData } = require('../controllers/osm-legacy');
+
+describe('transformMemberGridData', () => {
+  const buildRawData = (memberOverrides = {}) => ({
+    status: true,
+    error: null,
+    data: {
+      '12345': {
+        first_name: 'Alex',
+        last_name: 'Johnson',
+        age: '10 / 06',
+        patrol: 'Red Six',
+        patrol_id: 7,
+        active: true,
+        joined: '2023-01-01',
+        started: '2023-01-01',
+        end_date: null,
+        date_of_birth: '2015-06-01',
+        section_id: 999,
+        photo_guid: '1865f4ca-df43-489d-9bc2-a1e7570a5a30',
+        pic: true,
+        ...memberOverrides,
+      },
+    },
+    meta: { structure: [] },
+  });
+
+  it('preserves photo_guid and pic on transformed members', () => {
+    const result = transformMemberGridData(buildRawData());
+
+    expect(result.status).toBe(true);
+    expect(result.data.members).toHaveLength(1);
+    expect(result.data.members[0].photo_guid).toBe('1865f4ca-df43-489d-9bc2-a1e7570a5a30');
+    expect(result.data.members[0].pic).toBe(true);
+  });
+
+  it('defaults photo_guid to null and pic to false when absent', () => {
+    const result = transformMemberGridData(buildRawData({ photo_guid: undefined, pic: undefined }));
+
+    expect(result.data.members[0].photo_guid).toBeNull();
+    expect(result.data.members[0].pic).toBe(false);
+  });
+});

--- a/controllers/osm-legacy.js
+++ b/controllers/osm-legacy.js
@@ -127,6 +127,8 @@ const transformMemberGridData = (rawData) => {
       end_date: memberData.end_date,
       date_of_birth: memberData.date_of_birth,
       section_id: memberData.section_id,
+      photo_guid: memberData.photo_guid ?? null,
+      pic: memberData.pic ?? false,
     };
     
     // Transform custom_data using column mapping to create flattened fields only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-osm-backend",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Backend API for Vikings OSM Event Manager with rate limiting and OAuth",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Summary

The frontend Sections page photo feature (frontend PR Walton-Viking-Scouts/VikingsEventMgmt#208) showed only initials because `/get-members-grid` never returned photo data.

**Root cause:** `transformMemberGridData` in `controllers/osm-legacy.js` rebuilds each member from an explicit field whitelist — `photo_guid` and `pic` were not in it, so they were stripped even though OSM's raw grid response includes them (verified against `osm_examples/Members/member_grid.json`).

**Fix:** add `photo_guid` (default `null`) and `pic` (default `false`) to the transformed member object. The frontend already consumes both fields (`members.js` normalizes `photo_guid`/`has_photo`), so no frontend change is needed.

## Testing
- New unit tests for the transform: photo field passthrough + defaults when absent
- Full suite: 56 passed, 0 failures
- Version bumped to 1.1.4 for production deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ggpcDKLfmEg6A8WhTXSkq