### PR TITLE
chore: fix comma-dangle lint errors blocking release workflow

### DIFF
--- a/controllers/osm-legacy.js
+++ b/controllers/osm-legacy.js
@@ -22,7 +22,7 @@ const transformMemberGridData = (rawData) => {
     logger.error('Invalid OSM API data structure', logger.fmt({ 
       endpoint: 'osm-legacy.transformMemberGridData', 
       hasData: !!rawData?.data, 
-      hasMeta: !!rawData?.meta 
+      hasMeta: !!rawData?.meta, 
     }));
     Sentry?.captureMessage('transformMemberGridData: invalid OSM data structure', 'warning');
     
@@ -76,7 +76,7 @@ const transformMemberGridData = (rawData) => {
       logger.warn('createFieldName: invalid input', logger.fmt({ 
         endpoint: 'osm-legacy.transformMemberGridData', 
         groupName, 
-        columnLabel 
+        columnLabel, 
       }));
       return null;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-osm-backend",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Backend API for Vikings OSM Event Manager with rate limiting and OAuth",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Summary

The tag-triggered 🚀 Release workflow runs `npm run lint`, which has been failing on two pre-existing missing trailing commas in `controllers/osm-legacy.js` — broken since at least v1.3.0 (Sept 2025). Main-branch CI doesn't gate on lint, so PR checks never surfaced it.

Fixed via `eslint --fix` (2 characters). Version bumped to 1.1.5.

## Testing
- `npm run lint`: clean
- `npm test`: 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ggpcDKLfmEg6A8WhTXSkq