### PR TITLE
feat: add /get-programme-summary OSM proxy endpoint

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -122,6 +122,25 @@ describe('Vikings OSM Backend API', () => {
       expect(response2.body.error).toContain('sectionid');
     });
 
+    test('GET /get-programme-summary should require access token, sectionid, and termid', async () => {
+      const response1 = await request(app)
+        .get('/get-programme-summary')
+        .query({})
+        .expect(401);
+
+      expect(response1.body).toHaveProperty('error');
+      expect(response1.body.error).toContain('Access token is required');
+
+      const response2 = await request(app)
+        .get('/get-programme-summary')
+        .set('Authorization', 'Bearer test_token')
+        .query({ sectionid: '49097' })
+        .expect(400);
+
+      expect(response2.body).toHaveProperty('error');
+      expect(response2.body.error).toContain('termid');
+    });
+
     test('GET /get-flexi-structure should require access token, sectionid, and flexirecordid', async () => {
       // First test without authorization token - should get 401
       const response1 = await request(app)

--- a/controllers/osm.js
+++ b/controllers/osm.js
@@ -164,6 +164,26 @@ const getEvents = osmEndpoints.getEvents();
 const getEventAttendance = osmEndpoints.getEventAttendance();
 
 /**
+ * OSM: Get the programme summary (meeting list) for a section and term.
+ *
+ * Proxies the OSM API `action=getProgrammeSummary` with `verbose=1`. Used by
+ * the frontend water-rota feature to derive session dates from each
+ * section's programme.
+ *
+ * @tags OSM
+ * @route GET /get-programme-summary
+ * @header Authorization {string}
+ * @param {string|number} query.sectionid - Section id
+ * @param {string|number} query.termid - Term id
+ * @returns {object} 200 - Programme meetings for the term
+ * @example Success response
+ * { "items": [ { "eveningid": "8785585", "title": "Water night", "meetingdate": "2026-06-02" } ] }
+ * @example Error response (missing params)
+ * { "error": "Missing required parameters: sectionid, termid" }
+ */
+const getProgrammeSummary = osmEndpoints.getProgrammeSummary();
+
+/**
  * OSM: Get detailed event summary.
  *
  * @tags OSM
@@ -615,6 +635,9 @@ module.exports = {
   getEventSummary,
   getEventSharingStatus,
   getSharedEventAttendance,
+
+  // Programme
+  getProgrammeSummary,
 
   // Members and Contacts
   getContactDetails,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-osm-backend",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Backend API for Vikings OSM Event Manager with rate limiting and OAuth",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -639,6 +639,13 @@ app.get('/get-events', osmController.getEvents); // Updated to GET
 app.get('/get-event-attendance', osmController.getEventAttendance);
 
 /**
+ * OSM: Programme summary proxy (meeting list for a section/term).
+ * @tags OSM
+ * @route GET /get-programme-summary
+ */
+app.get('/get-programme-summary', osmController.getProgrammeSummary);
+
+/**
  * OSM: Event sharing status proxy.
  * @tags OSM
  * @route GET /get-event-sharing-status

--- a/utils/osmEndpointFactories.js
+++ b/utils/osmEndpointFactories.js
@@ -410,6 +410,12 @@ const osmEndpoints = {
     'https://www.onlinescoutmanager.co.uk/ext/events/event/?action=getAttendance',
     ['sectionid', 'termid', 'eventid'],
   ),
+
+  getProgrammeSummary: () => createSimpleGetHandler(
+    'getProgrammeSummary',
+    'https://www.onlinescoutmanager.co.uk/ext/programme/?action=getProgrammeSummary&verbose=1',
+    ['sectionid', 'termid'],
+  ),
   
   // Contact-related endpoints (with special handling)
   getContactDetails: () => createContactHandler(


### PR DESCRIPTION
## Summary

Adds a read-only proxy for OSM's programme summary — `GET /get-programme-summary?sectionid=X&termid=Y` → `ext/programme/?action=getProgrammeSummary&verbose=1`.

This supports the frontend **Water Session Permit Rota** feature (frontend PR: Walton-Viking-Scouts/VikingsEventMgmt#211), which derives on-water session dates from each section's programme meetings instead of manual entry.

- Uses the existing `section:programme:read` OAuth scope (already requested at authorization) — no scope change.
- Follows the `osmEndpointFactories` simple-GET pattern (same shape as `/get-event-attendance`); rate limiting, token validation, and error handling come from the shared handler.
- `verbose=1` passed through in case OSM includes meeting times; the frontend tolerates their absence.

## Test plan

- New test: 401 without token, 400 with missing `termid`.
- `npm run lint` ✅ · `npm test` ✅ (62 passed)
- Version bumped to v1.2.0 per the pre-merge auto-deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR