### PR TITLE
fix: capture the full OSM block page in the OAuth-HTML-error log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-osm-backend",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Backend API for Vikings OSM Event Manager with rate limiting and OAuth",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -1409,7 +1409,7 @@ app.get('/oauth/callback', async (req, res) => {
           contentType,
           responseLength: rawResponseText ? rawResponseText.length : 0,
           responsePreview: rawResponseText
-            ? rawResponseText.substring(0, 500)
+            ? rawResponseText.substring(0, 2000)
             : 'No response text',
           isHTML: looksHTML || contentType.includes('text/html'),
           section: 'oauth-token-exchange',
@@ -1418,11 +1418,13 @@ app.get('/oauth/callback', async (req, res) => {
         });
 
         if (looksHTML || contentType.includes('text/html')) {
-          // HTML response - this is the error we're trying to capture
+          // HTML response - this is the error we're trying to capture.
+          // Capture a wide preview (OSM's "Blocked" page is ~8-9KB) so the full
+          // block message/reason is visible in Sentry, not just the <head>.
           logger.error('OSM returned HTML instead of JSON - likely blocking/error page', {
             status: tokenResponse.status,
             statusText: tokenResponse.statusText,
-            html_preview: rawResponseText.substring(0, 1000),
+            html_preview: rawResponseText.substring(0, 15000),
             html_length: rawResponseText.length,
             contentType,
             section: 'oauth-html-error',


### PR DESCRIPTION
When OSM rate-limit-blocks the app, `/oauth/token` returns an ~8-9KB HTML **"Online Scout Manager (OSM): Blocked"** page (HTTP **200**) instead of a token. We only logged the first **1000** chars of `html_preview` — just the `<head>` — so the actual block reason/instructions in the `<body>` were cut off.

Widen `html_preview` on the `OSM returned HTML` error log to **15000** chars (whole page) and the general `responsePreview` to 2000. **Logging-only, no behaviour change.** v1.2.1.

Context: today's login outage was this OSM block. See frontend PR #222 which surfaces it to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)