### PR TITLE
feat: global OSM circuit breaker with hourly half-open probe + admin endpoint

### DIFF
--- a/__tests__/osmCircuitBreaker.test.js
+++ b/__tests__/osmCircuitBreaker.test.js
@@ -49,8 +49,9 @@ describe('osmCircuitBreaker', () => {
     breaker.recordBlocked();
     jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
     breaker.shouldAllowRequest();
+    const generation = breaker.getGeneration();
 
-    breaker.recordSuccess();
+    breaker.recordSuccess(generation);
 
     const status = breaker.getStatus();
     expect(status.state).toBe('closed');
@@ -77,8 +78,9 @@ describe('osmCircuitBreaker', () => {
     breaker.recordBlocked();
     jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
     breaker.shouldAllowRequest();
+    const generation = breaker.getGeneration();
 
-    breaker.recordProbeFailure();
+    breaker.recordProbeFailure(generation);
 
     expect(breaker.getStatus().state).toBe('open');
     expect(breaker.shouldAllowRequest()).toBe(true);
@@ -87,12 +89,12 @@ describe('osmCircuitBreaker', () => {
 
   it('no-ops recordProbeFailure when not half-open', () => {
     expect(breaker.getStatus().state).toBe('closed');
-    breaker.recordProbeFailure();
+    breaker.recordProbeFailure(breaker.getGeneration());
     expect(breaker.getStatus().state).toBe('closed');
   });
 
   it('no-ops recordSuccess when already closed', () => {
-    breaker.recordSuccess();
+    breaker.recordSuccess(breaker.getGeneration());
     expect(breaker.getStatus().tripCount).toBe(0);
     expect(breaker.getStatus().state).toBe('closed');
   });
@@ -129,5 +131,46 @@ describe('osmCircuitBreaker', () => {
     const status = breaker.getStatus();
     expect(status.secondsUntilProbe).toBeGreaterThan(0);
     expect(status.secondsUntilProbe).toBeLessThanOrEqual(Math.ceil(COOLDOWN_MS / 1000));
+  });
+
+  describe('TOCTOU generation guard', () => {
+    it('ignores a stale recordSuccess from before a fresh trip, so the breaker stays open', () => {
+      const staleGeneration = breaker.getGeneration();
+
+      breaker.trip();
+      breaker.recordSuccess(staleGeneration);
+
+      expect(breaker.getStatus().state).toBe('open');
+      expect(breaker.shouldAllowRequest()).toBe(false);
+    });
+
+    it('ignores a stale recordProbeFailure from before the trip that started the probe, leaving the probe in flight', () => {
+      const staleGeneration = breaker.getGeneration();
+
+      breaker.recordBlocked();
+      jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
+      expect(breaker.shouldAllowRequest()).toBe(true);
+      expect(breaker.getStatus().state).toBe('half-open');
+      const currentGeneration = breaker.getGeneration();
+
+      breaker.recordProbeFailure(staleGeneration);
+
+      expect(breaker.getStatus().state).toBe('half-open');
+      expect(breaker.shouldAllowRequest()).toBe(false);
+
+      breaker.recordSuccess(currentGeneration);
+      expect(breaker.getStatus().state).toBe('closed');
+    });
+
+    it('ignores a pre-reset generation after a subsequent trip', () => {
+      breaker.recordBlocked();
+      const preResetGeneration = breaker.getGeneration();
+
+      breaker.reset();
+      breaker.trip();
+      breaker.recordSuccess(preResetGeneration);
+
+      expect(breaker.getStatus().state).toBe('open');
+    });
   });
 });

--- a/__tests__/osmCircuitBreaker.test.js
+++ b/__tests__/osmCircuitBreaker.test.js
@@ -1,0 +1,133 @@
+const breaker = require('../utils/osmCircuitBreaker');
+
+const COOLDOWN_MS = 60 * 60 * 1000;
+
+describe('osmCircuitBreaker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    breaker.reset();
+  });
+
+  afterEach(() => {
+    breaker.reset();
+    jest.useRealTimers();
+  });
+
+  it('allows requests when closed', () => {
+    expect(breaker.shouldAllowRequest()).toBe(true);
+    expect(breaker.getStatus().state).toBe('closed');
+  });
+
+  it('opens on recordBlocked', () => {
+    breaker.recordBlocked();
+    const status = breaker.getStatus();
+    expect(status.state).toBe('open');
+    expect(status.tripCount).toBe(1);
+    expect(status.trippedAt).toBe(new Date('2026-01-01T00:00:00Z').toISOString());
+  });
+
+  it('denies requests while open and before the cooldown elapses', () => {
+    breaker.recordBlocked();
+    jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS - 1000));
+    expect(breaker.shouldAllowRequest()).toBe(false);
+    expect(breaker.getStatus().state).toBe('open');
+  });
+
+  it('allows exactly one caller through as the probe once the cooldown elapses', () => {
+    breaker.recordBlocked();
+    jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
+
+    expect(breaker.shouldAllowRequest()).toBe(true);
+    expect(breaker.getStatus().state).toBe('half-open');
+
+    expect(breaker.shouldAllowRequest()).toBe(false);
+    expect(breaker.shouldAllowRequest()).toBe(false);
+  });
+
+  it('closes and recovers when the half-open probe succeeds', () => {
+    breaker.recordBlocked();
+    jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
+    breaker.shouldAllowRequest();
+
+    breaker.recordSuccess();
+
+    const status = breaker.getStatus();
+    expect(status.state).toBe('closed');
+    expect(status.trippedAt).toBeNull();
+    expect(breaker.shouldAllowRequest()).toBe(true);
+  });
+
+  it('re-opens with a fresh trippedAt when recordBlocked fires from half-open', () => {
+    breaker.recordBlocked();
+    const firstTrippedAt = breaker.getStatus().trippedAt;
+    jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
+    breaker.shouldAllowRequest();
+
+    jest.setSystemTime(new Date(Date.now() + 1000));
+    breaker.recordBlocked();
+
+    const status = breaker.getStatus();
+    expect(status.state).toBe('open');
+    expect(status.tripCount).toBe(2);
+    expect(status.trippedAt).not.toBe(firstTrippedAt);
+  });
+
+  it('leaves the breaker open on recordProbeFailure but allows the next request to probe again', () => {
+    breaker.recordBlocked();
+    jest.setSystemTime(new Date(Date.now() + COOLDOWN_MS));
+    breaker.shouldAllowRequest();
+
+    breaker.recordProbeFailure();
+
+    expect(breaker.getStatus().state).toBe('open');
+    expect(breaker.shouldAllowRequest()).toBe(true);
+    expect(breaker.getStatus().state).toBe('half-open');
+  });
+
+  it('no-ops recordProbeFailure when not half-open', () => {
+    expect(breaker.getStatus().state).toBe('closed');
+    breaker.recordProbeFailure();
+    expect(breaker.getStatus().state).toBe('closed');
+  });
+
+  it('no-ops recordSuccess when already closed', () => {
+    breaker.recordSuccess();
+    expect(breaker.getStatus().tripCount).toBe(0);
+    expect(breaker.getStatus().state).toBe('closed');
+  });
+
+  it('force-closes on reset', () => {
+    breaker.recordBlocked();
+    breaker.reset();
+    const status = breaker.getStatus();
+    expect(status.state).toBe('closed');
+    expect(status.trippedAt).toBeNull();
+    expect(breaker.shouldAllowRequest()).toBe(true);
+  });
+
+  it('force-opens on trip', () => {
+    breaker.trip();
+    expect(breaker.getStatus().state).toBe('open');
+    expect(breaker.shouldAllowRequest()).toBe(false);
+  });
+
+  it('returns the documented getStatus shape', () => {
+    const status = breaker.getStatus();
+    expect(status).toEqual({
+      state: 'closed',
+      trippedAt: null,
+      tripCount: 0,
+      cooldownMs: COOLDOWN_MS,
+      secondsUntilProbe: null,
+    });
+  });
+
+  it('reports secondsUntilProbe counting down while open', () => {
+    breaker.recordBlocked();
+    jest.setSystemTime(new Date(Date.now() + 1000));
+    const status = breaker.getStatus();
+    expect(status.secondsUntilProbe).toBeGreaterThan(0);
+    expect(status.secondsUntilProbe).toBeLessThanOrEqual(Math.ceil(COOLDOWN_MS / 1000));
+  });
+});

--- a/__tests__/osmCircuitBreakerIntegration.test.js
+++ b/__tests__/osmCircuitBreakerIntegration.test.js
@@ -1,0 +1,172 @@
+const request = require('supertest');
+
+require('dotenv').config();
+
+process.env.OAUTH_CLIENT_ID = process.env.OAUTH_CLIENT_ID || 'test_client_id';
+process.env.OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET || 'test_client_secret';
+
+global.setInterval = jest.fn();
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: { get: jest.fn(() => null) },
+    json: () => Promise.resolve({ data: 'test' }),
+    text: () => Promise.resolve('{"data":"test"}'),
+  }),
+);
+
+const app = require('../server');
+const breaker = require('../utils/osmCircuitBreaker');
+
+describe('OSM circuit breaker gating', () => {
+  const originalAdminKey = process.env.ADMIN_API_KEY;
+
+  beforeEach(() => {
+    breaker.reset();
+    fetch.mockClear();
+  });
+
+  afterEach(() => {
+    breaker.reset();
+    if (originalAdminKey === undefined) {
+      delete process.env.ADMIN_API_KEY;
+    } else {
+      process.env.ADMIN_API_KEY = originalAdminKey;
+    }
+  });
+
+  describe('factory-created endpoint', () => {
+    it('proxies normally while the breaker is closed', async () => {
+      const res = await request(app)
+        .get('/get-terms')
+        .set('Authorization', 'Bearer test-token');
+
+      expect(res.status).toBe(200);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 503 blocked without calling OSM when the breaker is open', async () => {
+      breaker.trip();
+
+      const res = await request(app)
+        .get('/get-terms')
+        .set('Authorization', 'Bearer test-token');
+
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({
+        error: 'OSM API access blocked - sign in again to reconnect',
+        blocked: true,
+      });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startup data handler', () => {
+    it('returns 503 blocked without calling OSM when the breaker is open', async () => {
+      breaker.trip();
+
+      const res = await request(app)
+        .get('/get-startup-data')
+        .set('Authorization', 'Bearer test-token');
+
+      expect(res.status).toBe(503);
+      expect(res.body.blocked).toBe(true);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /admin/osm-breaker', () => {
+    it('returns 503 when ADMIN_API_KEY is not configured', async () => {
+      delete process.env.ADMIN_API_KEY;
+
+      const res = await request(app)
+        .get('/admin/osm-breaker')
+        .set('x-admin-key', 'anything');
+
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({ error: 'Admin endpoint not configured' });
+    });
+
+    it('returns 401 when the key is wrong', async () => {
+      process.env.ADMIN_API_KEY = 'correct-key';
+
+      const res = await request(app)
+        .get('/admin/osm-breaker')
+        .set('x-admin-key', 'wrong-key');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when the key header is missing', async () => {
+      process.env.ADMIN_API_KEY = 'correct-key';
+
+      const res = await request(app).get('/admin/osm-breaker');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns the breaker status with the correct key', async () => {
+      process.env.ADMIN_API_KEY = 'correct-key';
+
+      const res = await request(app)
+        .get('/admin/osm-breaker')
+        .set('x-admin-key', 'correct-key');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        state: 'closed',
+        trippedAt: null,
+        tripCount: 0,
+        cooldownMs: 60 * 60 * 1000,
+        secondsUntilProbe: null,
+      });
+    });
+  });
+
+  describe('POST /admin/osm-breaker', () => {
+    beforeEach(() => {
+      process.env.ADMIN_API_KEY = 'correct-key';
+    });
+
+    it('trips the breaker', async () => {
+      const res = await request(app)
+        .post('/admin/osm-breaker')
+        .set('x-admin-key', 'correct-key')
+        .send({ action: 'trip' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.state).toBe('open');
+    });
+
+    it('resets the breaker', async () => {
+      breaker.trip();
+
+      const res = await request(app)
+        .post('/admin/osm-breaker')
+        .set('x-admin-key', 'correct-key')
+        .send({ action: 'reset' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.state).toBe('closed');
+    });
+
+    it('returns 400 for an unknown action', async () => {
+      const res = await request(app)
+        .post('/admin/osm-breaker')
+        .set('x-admin-key', 'correct-key')
+        .send({ action: 'bogus' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 401 for a wrong key', async () => {
+      const res = await request(app)
+        .post('/admin/osm-breaker')
+        .set('x-admin-key', 'wrong-key')
+        .send({ action: 'trip' });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-osm-backend",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikings-osm-backend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Backend API for Vikings OSM Event Manager with rate limiting and OAuth",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -31,6 +31,8 @@ const {
   oAuthCallbackLogger,
 } = require('./utils/serverHelpers');
 const { osmHealthLogger } = require('./utils/osmHealthLogger');
+const { detectBlockedResponse } = require('./utils/responseHelpers');
+const osmCircuitBreaker = require('./utils/osmCircuitBreaker');
 
 // Successfully loaded documentation
 console.log('✅ Frontend API docs loaded:', frontendApiDocs.specs.info.title, '(' + Object.keys(frontendApiDocs.specs.paths).length + ' endpoints)');
@@ -601,6 +603,67 @@ app.post('/admin/tokens/clear', (req, res) => {
     message: `Cleared all ${clearedCount} tokens`,
     remaining: 0,
   });
+});
+
+/**
+ * Validates the x-admin-key header against process.env.ADMIN_API_KEY.
+ * Fails closed: an unset/empty ADMIN_API_KEY means the endpoint refuses
+ * everyone rather than accepting an empty key as valid.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {boolean} True if the caller is authorized (response untouched)
+ */
+const requireAdminKey = (req, res) => {
+  const adminKey = process.env.ADMIN_API_KEY;
+  if (!adminKey) {
+    res.status(503).json({ error: 'Admin endpoint not configured' });
+    return false;
+  }
+  if (req.headers['x-admin-key'] !== adminKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Admin: Inspect the OSM circuit breaker state.
+ * @tags Admin
+ * @route GET /admin/osm-breaker
+ * @returns {object} 200 - Breaker status
+ * @returns {object} 401 - Wrong or missing x-admin-key
+ * @returns {object} 503 - ADMIN_API_KEY not configured
+ */
+app.get('/admin/osm-breaker', (req, res) => {
+  if (!requireAdminKey(req, res)) {
+    return;
+  }
+  res.json(osmCircuitBreaker.getStatus());
+});
+
+/**
+ * Admin: Force-trip or force-reset the OSM circuit breaker.
+ * @tags Admin
+ * @route POST /admin/osm-breaker
+ * @param {object} req.body - { "action": "trip" | "reset" }
+ * @returns {object} 200 - Updated breaker status
+ * @returns {object} 400 - Unknown action
+ * @returns {object} 401 - Wrong or missing x-admin-key
+ * @returns {object} 503 - ADMIN_API_KEY not configured
+ */
+app.post('/admin/osm-breaker', (req, res) => {
+  if (!requireAdminKey(req, res)) {
+    return;
+  }
+  const { action } = req.body || {};
+  if (action === 'trip') {
+    osmCircuitBreaker.trip();
+  } else if (action === 'reset') {
+    osmCircuitBreaker.reset();
+  } else {
+    return res.status(400).json({ error: `Unknown action: ${action}` });
+  }
+  res.json(osmCircuitBreaker.getStatus());
 });
 
 /**
@@ -1418,6 +1481,9 @@ app.get('/oauth/callback', async (req, res) => {
         });
 
         if (looksHTML || contentType.includes('text/html')) {
+          if (detectBlockedResponse(rawResponseText)) {
+            osmCircuitBreaker.recordBlocked();
+          }
           // HTML response - this is the error we're trying to capture.
           // Capture a wide preview (OSM's "Blocked" page is ~8-9KB) so the full
           // block message/reason is visible in Sentry, not just the <head>.
@@ -1510,6 +1576,7 @@ app.get('/oauth/callback', async (req, res) => {
 
     // Log successful token exchange
     osmHealthLogger.logTokenExchange(true, tokenData);
+    osmCircuitBreaker.recordSuccess();
 
     if (!tokenData.access_token) {
       (logger?.error || console.error)('Missing access_token at redirect-build (defensive guard)', {

--- a/server.js
+++ b/server.js
@@ -1406,6 +1406,8 @@ app.get('/oauth/callback', async (req, res) => {
     
     oAuthCallbackLogger.logTokenExchange(tokenPayload);
 
+    const breakerGeneration = osmCircuitBreaker.getGeneration();
+
     // Retry logic for token exchange with better timeout handling
     let tokenResponse;
     const maxRetries = 2;
@@ -1576,7 +1578,7 @@ app.get('/oauth/callback', async (req, res) => {
 
     // Log successful token exchange
     osmHealthLogger.logTokenExchange(true, tokenData);
-    osmCircuitBreaker.recordSuccess();
+    osmCircuitBreaker.recordSuccess(breakerGeneration);
 
     if (!tokenData.access_token) {
       (logger?.error || console.error)('Missing access_token at redirect-build (defensive guard)', {

--- a/utils/osmApiHandler.js
+++ b/utils/osmApiHandler.js
@@ -7,6 +7,12 @@ const {
 
 const { logger } = require('../config/sentry');
 const { detectBlockedResponse } = require('./responseHelpers');
+const {
+  shouldAllowRequest,
+  recordBlocked,
+  recordSuccess,
+  recordProbeFailure,
+} = require('./osmCircuitBreaker');
 const fallbackLogger = {
   info: console.log,
   warn: console.warn,
@@ -113,6 +119,7 @@ const processOSMResponse = async (response, responseText, processResponse, req, 
     data = JSON.parse(responseText);
   } catch (parseError) {
     if (detectBlockedResponse(responseText)) {
+      recordBlocked();
       endpointLogger.error('OSM returned Blocked page', {
         parseError: parseError.message,
         responseLength: responseText.length,
@@ -147,6 +154,8 @@ const processOSMResponse = async (response, responseText, processResponse, req, 
   if (processResponse) {
     data = processResponse(data, req);
   }
+
+  recordSuccess();
 
   // Success logging
   endpointLogger.info('Request completed successfully', {
@@ -203,6 +212,14 @@ const createOSMApiHandler = (endpoint, config) => {
       return res.status(validationError.status).json(validationError.json);
     }
 
+    if (!shouldAllowRequest()) {
+      endpointLogger.warn('OSM circuit breaker open - request blocked without calling OSM');
+      return res.status(503).json({
+        error: 'OSM API access blocked - sign in again to reconnect',
+        blocked: true,
+      });
+    }
+
     try {
       // Build request URL and options
       const url = buildUrl(req);
@@ -223,12 +240,13 @@ const createOSMApiHandler = (endpoint, config) => {
 
       // Handle rate limiting
       if (response.status === 429) {
+        recordProbeFailure();
         const osmInfo = getOSMRateLimitInfo(sessionId);
         endpointLogger.warn('Rate limit exceeded', {
           status: response.status,
           rateLimitInfo: osmInfo,
         });
-        return res.status(429).json({ 
+        return res.status(429).json({
           error: 'OSM API rate limit exceeded',
           rateLimitInfo: osmInfo,
           message: 'Please wait before making more requests',
@@ -237,13 +255,14 @@ const createOSMApiHandler = (endpoint, config) => {
 
       // Handle non-OK responses
       if (!response.ok) {
+        recordProbeFailure();
         const errorText = await response.text();
         endpointLogger.error('OSM API error', {
           status: response.status,
           statusText: response.statusText,
           errorText: errorText.substring(0, 500),
         });
-        return res.status(response.status).json({ 
+        return res.status(response.status).json({
           error: `OSM API error: ${response.status}`,
           details: errorText,
         });
@@ -259,6 +278,7 @@ const createOSMApiHandler = (endpoint, config) => {
       
       // Check if processing returned an error
       if (processResult.status) {
+        recordProbeFailure();
         return res.status(processResult.status).json(processResult.json);
       }
 
@@ -267,6 +287,7 @@ const createOSMApiHandler = (endpoint, config) => {
       res.json(responseWithRateInfo);
 
     } catch (err) {
+      recordProbeFailure();
       const status = Number.isInteger(err.status) ? err.status : 500;
       const isClientError = status >= 400 && status < 500;
       endpointLogger.error(isClientError ? 'Request validation failed' : 'Internal server error', {

--- a/utils/osmApiHandler.js
+++ b/utils/osmApiHandler.js
@@ -12,6 +12,7 @@ const {
   recordBlocked,
   recordSuccess,
   recordProbeFailure,
+  getGeneration,
 } = require('./osmCircuitBreaker');
 const fallbackLogger = {
   info: console.log,
@@ -155,8 +156,6 @@ const processOSMResponse = async (response, responseText, processResponse, req, 
     data = processResponse(data, req);
   }
 
-  recordSuccess();
-
   // Success logging
   endpointLogger.info('Request completed successfully', {
     status: response.status,
@@ -220,6 +219,8 @@ const createOSMApiHandler = (endpoint, config) => {
       });
     }
 
+    const breakerGeneration = getGeneration();
+
     try {
       // Build request URL and options
       const url = buildUrl(req);
@@ -240,7 +241,7 @@ const createOSMApiHandler = (endpoint, config) => {
 
       // Handle rate limiting
       if (response.status === 429) {
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         const osmInfo = getOSMRateLimitInfo(sessionId);
         endpointLogger.warn('Rate limit exceeded', {
           status: response.status,
@@ -255,7 +256,7 @@ const createOSMApiHandler = (endpoint, config) => {
 
       // Handle non-OK responses
       if (!response.ok) {
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         const errorText = await response.text();
         endpointLogger.error('OSM API error', {
           status: response.status,
@@ -278,16 +279,18 @@ const createOSMApiHandler = (endpoint, config) => {
       
       // Check if processing returned an error
       if (processResult.status) {
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         return res.status(processResult.status).json(processResult.json);
       }
+
+      recordSuccess(breakerGeneration);
 
       // Send successful response with rate limit info
       const responseWithRateInfo = addRateLimitInfoToResponse(req, res, processResult.data);
       res.json(responseWithRateInfo);
 
     } catch (err) {
-      recordProbeFailure();
+      recordProbeFailure(breakerGeneration);
       const status = Number.isInteger(err.status) ? err.status : 500;
       const isClientError = status >= 400 && status < 500;
       endpointLogger.error(isClientError ? 'Request validation failed' : 'Internal server error', {

--- a/utils/osmCircuitBreaker.js
+++ b/utils/osmCircuitBreaker.js
@@ -1,0 +1,145 @@
+const { logger } = require('../config/sentry');
+
+const COOLDOWN_MS = 60 * 60 * 1000;
+
+const STATE_CLOSED = 'closed';
+const STATE_OPEN = 'open';
+const STATE_HALF_OPEN = 'half-open';
+
+let state = STATE_CLOSED;
+let trippedAt = null;
+let tripCount = 0;
+let probeInFlight = false;
+
+/**
+ * Builds the status snapshot shared by getStatus() and log calls.
+ * @returns {{state: string, trippedAt: string|null, tripCount: number, cooldownMs: number, secondsUntilProbe: number|null}}
+ */
+const buildStatus = () => {
+  let secondsUntilProbe = null;
+  if (state !== STATE_CLOSED && trippedAt !== null) {
+    const remainingMs = trippedAt + COOLDOWN_MS - Date.now();
+    secondsUntilProbe = Math.max(0, Math.ceil(remainingMs / 1000));
+  }
+  return {
+    state,
+    trippedAt: trippedAt !== null ? new Date(trippedAt).toISOString() : null,
+    tripCount,
+    cooldownMs: COOLDOWN_MS,
+    secondsUntilProbe,
+  };
+};
+
+/**
+ * Trips the breaker to open, stamping a fresh trippedAt and incrementing
+ * tripCount. Used both when OSM's Blocked page is detected and for
+ * admin/testing force-open.
+ * @returns {void}
+ */
+const trip = () => {
+  state = STATE_OPEN;
+  trippedAt = Date.now();
+  tripCount += 1;
+  probeInFlight = false;
+  logger.error('OSM circuit breaker tripped', buildStatus());
+};
+
+/**
+ * Called when a Blocked page is detected on any OSM-facing request.
+ * Alias for trip() - kept as a separate name so call sites read intent.
+ * @returns {void}
+ */
+const recordBlocked = () => {
+  trip();
+};
+
+/**
+ * Determines whether a new request may proceed to OSM.
+ * Closed: always allows. Open: denies until the hourly cooldown has
+ * elapsed since trippedAt, at which point it transitions to half-open and
+ * allows exactly one caller through as the probe - concurrent callers
+ * during that same open window keep getting denied until the probe
+ * resolves (recordSuccess/recordProbeFailure) or the breaker is reset.
+ * @returns {boolean} True if the request may proceed
+ */
+const shouldAllowRequest = () => {
+  if (state === STATE_CLOSED) {
+    return true;
+  }
+
+  if (state === STATE_HALF_OPEN) {
+    return false;
+  }
+
+  const cooldownElapsed = trippedAt !== null && Date.now() - trippedAt >= COOLDOWN_MS;
+  if (!cooldownElapsed || probeInFlight) {
+    return false;
+  }
+
+  state = STATE_HALF_OPEN;
+  probeInFlight = true;
+  logger.info('OSM circuit breaker probing', buildStatus());
+  return true;
+};
+
+/**
+ * Called on any successfully-parsed OSM response. Closes the breaker if it
+ * was half-open or open; no-op when already closed.
+ * @returns {void}
+ */
+const recordSuccess = () => {
+  if (state === STATE_CLOSED) {
+    return;
+  }
+  const wasHalfOpen = state === STATE_HALF_OPEN;
+  state = STATE_CLOSED;
+  trippedAt = null;
+  probeInFlight = false;
+  if (wasHalfOpen) {
+    logger.info('OSM circuit breaker recovered', buildStatus());
+  }
+};
+
+/**
+ * Called when the half-open probe request fails for a non-blocked reason
+ * (network error, non-HTML error, etc). No-ops unless the breaker is
+ * currently half-open. Clears probe-in-flight and returns to open WITHOUT
+ * resetting trippedAt to now, so the next request immediately becomes the
+ * next probe attempt rather than the cooldown being pushed out another
+ * full hour.
+ * @returns {void}
+ */
+const recordProbeFailure = () => {
+  if (state !== STATE_HALF_OPEN) {
+    return;
+  }
+  state = STATE_OPEN;
+  probeInFlight = false;
+};
+
+/**
+ * Force-closes the breaker and clears its history (admin use / test isolation).
+ * @returns {void}
+ */
+const reset = () => {
+  state = STATE_CLOSED;
+  trippedAt = null;
+  tripCount = 0;
+  probeInFlight = false;
+};
+
+/**
+ * Returns the current breaker status.
+ * @returns {{state: string, trippedAt: string|null, tripCount: number, cooldownMs: number, secondsUntilProbe: number|null}}
+ */
+const getStatus = () => buildStatus();
+
+module.exports = {
+  shouldAllowRequest,
+  recordBlocked,
+  recordSuccess,
+  recordProbeFailure,
+  reset,
+  trip,
+  getStatus,
+};

--- a/utils/osmCircuitBreaker.js
+++ b/utils/osmCircuitBreaker.js
@@ -10,6 +10,7 @@ let state = STATE_CLOSED;
 let trippedAt = null;
 let tripCount = 0;
 let probeInFlight = false;
+let generation = 0;
 
 /**
  * Builds the status snapshot shared by getStatus() and log calls.
@@ -41,6 +42,7 @@ const trip = () => {
   trippedAt = Date.now();
   tripCount += 1;
   probeInFlight = false;
+  generation += 1;
   logger.error('OSM circuit breaker tripped', buildStatus());
 };
 
@@ -85,9 +87,17 @@ const shouldAllowRequest = () => {
 /**
  * Called on any successfully-parsed OSM response. Closes the breaker if it
  * was half-open or open; no-op when already closed.
+ * @param {number} observedGeneration - The generation captured by the caller
+ *   at the moment its request was dispatched (via getGeneration()). If a
+ *   trip()/reset() has since bumped the generation, this observation is
+ *   stale (TOCTOU: the request was in flight during a state change it never
+ *   observed) and must be ignored rather than force-closing a fresh trip.
  * @returns {void}
  */
-const recordSuccess = () => {
+const recordSuccess = (observedGeneration) => {
+  if (observedGeneration !== generation) {
+    return;
+  }
   if (state === STATE_CLOSED) {
     return;
   }
@@ -107,9 +117,16 @@ const recordSuccess = () => {
  * resetting trippedAt to now, so the next request immediately becomes the
  * next probe attempt rather than the cooldown being pushed out another
  * full hour.
+ * @param {number} observedGeneration - The generation captured by the caller
+ *   at the moment its request was dispatched (via getGeneration()). A stale
+ *   pre-trip failure landing during a genuine half-open probe must not be
+ *   allowed to end a probe cycle it never belonged to.
  * @returns {void}
  */
-const recordProbeFailure = () => {
+const recordProbeFailure = (observedGeneration) => {
+  if (observedGeneration !== generation) {
+    return;
+  }
   if (state !== STATE_HALF_OPEN) {
     return;
   }
@@ -126,6 +143,8 @@ const reset = () => {
   trippedAt = null;
   tripCount = 0;
   probeInFlight = false;
+  generation += 1;
+  logger.warn('OSM circuit breaker reset', buildStatus());
 };
 
 /**
@@ -133,6 +152,17 @@ const reset = () => {
  * @returns {{state: string, trippedAt: string|null, tripCount: number, cooldownMs: number, secondsUntilProbe: number|null}}
  */
 const getStatus = () => buildStatus();
+
+/**
+ * Returns the current generation counter. Callers should capture this right
+ * after shouldAllowRequest() passes and pass it back into recordSuccess()/
+ * recordProbeFailure() so a forced trip()/reset() during the request can
+ * invalidate that stale observation (TOCTOU guard). Not reusing tripCount
+ * for this because reset() zeroes tripCount, which could make a stale
+ * generation match again after a reset.
+ * @returns {number} The current generation
+ */
+const getGeneration = () => generation;
 
 module.exports = {
   shouldAllowRequest,
@@ -142,4 +172,5 @@ module.exports = {
   reset,
   trip,
   getStatus,
+  getGeneration,
 };

--- a/utils/osmEndpointFactories.js
+++ b/utils/osmEndpointFactories.js
@@ -12,6 +12,7 @@ const {
   recordBlocked,
   recordSuccess,
   recordProbeFailure,
+  getGeneration,
 } = require('./osmCircuitBreaker');
 
 /**
@@ -229,6 +230,8 @@ const createStartupHandler = (endpoint, baseUrl) => {
       });
     }
 
+    const breakerGeneration = getGeneration();
+
     try {
       const response = await makeOSMRequest(baseUrl, {
         method: 'GET',
@@ -238,7 +241,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
       }, sessionId);
 
       if (response.status === 429) {
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         const osmInfo = getOSMRateLimitInfo(sessionId);
         return res.status(429).json({
           error: 'OSM API rate limit exceeded',
@@ -261,7 +264,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
         }
 
         if (fallback.data) {
-          recordSuccess();
+          recordSuccess(breakerGeneration);
           logger.info('Startup data served from oauth/resource fallback', {
             sessionId,
             section: 'startup-fallback',
@@ -270,7 +273,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
           return res.json(responseWithRateInfo);
         }
 
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
 
         if (fallback.failureStatus === 429) {
           const osmInfo = getOSMRateLimitInfo(sessionId);
@@ -287,7 +290,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
       }
 
       if (!response.ok) {
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         return res.status(response.status).json({ error: `OSM API error: ${response.status}` });
       }
 
@@ -298,7 +301,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
 
       try {
         const data = JSON.parse(jsonText);
-        recordSuccess();
+        recordSuccess(breakerGeneration);
         const responseWithRateInfo = addRateLimitInfoToResponse(req, res, data);
         res.json(responseWithRateInfo);
       } catch (parseError) {
@@ -316,7 +319,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
             details: responseText.substring(0, 1000),
           });
         }
-        recordProbeFailure();
+        recordProbeFailure(breakerGeneration);
         logger.error('Invalid JSON in startup response from OSM API', {
           sessionId,
           parseError: parseError.message,
@@ -329,7 +332,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
         });
       }
     } catch (err) {
-      recordProbeFailure();
+      recordProbeFailure(breakerGeneration);
       res.status(500).json({ error: 'Internal Server Error', details: err.message });
     }
   };

--- a/utils/osmEndpointFactories.js
+++ b/utils/osmEndpointFactories.js
@@ -7,6 +7,12 @@ const {
 } = require('../middleware/rateLimiting');
 const { logger } = require('../config/sentry');
 const { detectBlockedResponse } = require('./responseHelpers');
+const {
+  shouldAllowRequest,
+  recordBlocked,
+  recordSuccess,
+  recordProbeFailure,
+} = require('./osmCircuitBreaker');
 
 /**
  * Creates a simple OSM GET endpoint handler
@@ -215,6 +221,14 @@ const createStartupHandler = (endpoint, baseUrl) => {
       return res.status(401).json({ error: 'Access token is required in Authorization header' });
     }
 
+    if (!shouldAllowRequest()) {
+      logger.warn('OSM circuit breaker open - startup request blocked without calling OSM', { sessionId });
+      return res.status(503).json({
+        error: 'OSM API access blocked - sign in again to reconnect',
+        blocked: true,
+      });
+    }
+
     try {
       const response = await makeOSMRequest(baseUrl, {
         method: 'GET',
@@ -224,8 +238,9 @@ const createStartupHandler = (endpoint, baseUrl) => {
       }, sessionId);
 
       if (response.status === 429) {
+        recordProbeFailure();
         const osmInfo = getOSMRateLimitInfo(sessionId);
-        return res.status(429).json({ 
+        return res.status(429).json({
           error: 'OSM API rate limit exceeded',
           rateLimitInfo: osmInfo,
           message: 'Please wait before making more requests',
@@ -246,6 +261,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
         }
 
         if (fallback.data) {
+          recordSuccess();
           logger.info('Startup data served from oauth/resource fallback', {
             sessionId,
             section: 'startup-fallback',
@@ -253,6 +269,8 @@ const createStartupHandler = (endpoint, baseUrl) => {
           const responseWithRateInfo = addRateLimitInfoToResponse(req, res, fallback.data);
           return res.json(responseWithRateInfo);
         }
+
+        recordProbeFailure();
 
         if (fallback.failureStatus === 429) {
           const osmInfo = getOSMRateLimitInfo(sessionId);
@@ -269,20 +287,23 @@ const createStartupHandler = (endpoint, baseUrl) => {
       }
 
       if (!response.ok) {
+        recordProbeFailure();
         return res.status(response.status).json({ error: `OSM API error: ${response.status}` });
       }
 
       const responseText = await response.text();
-      
+
       // OSM startup endpoint returns JavaScript code, remove first 18 characters to get JSON
       const jsonText = responseText.substring(18);
-      
+
       try {
         const data = JSON.parse(jsonText);
+        recordSuccess();
         const responseWithRateInfo = addRateLimitInfoToResponse(req, res, data);
         res.json(responseWithRateInfo);
       } catch (parseError) {
         if (detectBlockedResponse(responseText)) {
+          recordBlocked();
           logger.error('OSM returned Blocked page on startup data', {
             sessionId,
             parseError: parseError.message,
@@ -295,6 +316,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
             details: responseText.substring(0, 1000),
           });
         }
+        recordProbeFailure();
         logger.error('Invalid JSON in startup response from OSM API', {
           sessionId,
           parseError: parseError.message,
@@ -307,6 +329,7 @@ const createStartupHandler = (endpoint, baseUrl) => {
         });
       }
     } catch (err) {
+      recordProbeFailure();
       res.status(500).json({ error: 'Internal Server Error', details: err.message });
     }
   };


### PR DESCRIPTION
## Summary

Follow-up to #54. That PR made each *client* stop after one blocked 503 — but the backend still proxied every other user's requests straight to OSM while blocked. Since OSM's block is app-level (the Blocked page appears on `/oauth/token`, pre-auth), continued traffic risks escalation. This adds a **global in-memory circuit breaker**: while tripped, OSM sees zero traffic from the app.

## How it works

- **Trip**: Blocked page detected anywhere (proxy endpoints, startup data, oauth/callback) → breaker opens → every OSM-bound request returns the 503 blocked shape immediately, no OSM call.
- **Hourly half-open probe**: after 60 minutes, exactly **one** real user request is allowed through as the probe (single-probe guarantee via synchronous state flip — no async gap). Success closes the breaker; another Blocked page re-trips for another hour. A probe that fails for a *non-blocked* reason re-opens **without** restarting the hour, so the next request probes immediately.
- **No credentials, no cron**: the probe is the next genuine user request, carrying its own token. Logins are never gated, and a successful token exchange counts as recovery evidence and closes the breaker early.
- **In-memory**: a Northflank redeploy resets it — a free manual override.

## Admin / testing

- `GET /admin/osm-breaker` → status (state, trippedAt, tripCount, secondsUntilProbe)
- `POST /admin/osm-breaker` `{"action": "trip"|"reset"}`
- Auth: `x-admin-key` header vs `ADMIN_API_KEY` env var; **fails closed (503) when unconfigured**.

⚠️ **Post-merge action: add `ADMIN_API_KEY` to the Northflank environment** to enable the admin endpoint. To test end-to-end: trip it via the endpoint, watch the app show the blocked state + the Sentry event arrive, then reset.

## Notifications

Breaker trip logs at **error** level (`OSM circuit breaker tripped`) → new Sentry issue → email by default. Probe attempts and recovery log at info.

## Testing

23 new tests (state machine with fake timers incl. single-probe concurrency, gated-handler-returns-503-without-fetch, admin endpoint auth round-trip). Full suite 93/93, lint clean. Version bumped to **v1.2.3** pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rte229WWoYp3wKfgK59NnP